### PR TITLE
feat: implement create_note tool for notes API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ LunaTask MCP is an unofficial Model Context Protocol server that provides a stan
 ## Important Notes
 
 ### End-to-End Encryption
-LunaTask uses end-to-end encryption for sensitive task data. As a result:
-- Task `name` and `note` fields are **not included** in API responses
+LunaTask uses end-to-end encryption for sensitive task and note data. As a result:
+- Task `name`/`note` fields and note `content` are **not included** in API responses
 - Only non-sensitive metadata and structural information is available
 - This is a security feature of LunaTask and cannot be bypassed
-- The `name` and `note` fields **can be included** in create requests
+- The `name`, `note`, and `content` fields **can be included** in create requests
 - LunaTask automatically encrypts these fields client-side before storage
 - Once created, these fields will not be visible in GET responses due to E2E encryption
 - This is normal LunaTask behavior and ensures data privacy
@@ -172,6 +172,11 @@ coverage. Clients such as Claude Desktop, Claude Code, Cline, Continue, Roo Code
 
 ## Tools Available
 - `create_task`: Creates a new task. Requires `name` and the target `area_id`. Optional fields include text content (`note`), planning data (`status`, `scheduled_on`, `estimate`, `progress`), prioritisation (`priority`, `motivation`, `eisenhower`), goal context (`goal_id`) and external source metadata (`source`, `source_id`). Returns `{ "success": true, "task_id": "..." }` with the new identifier.
+- `create_note`: Creates a new note. Accepts `notebook_id`, `name`, optional `content`, `date_on`,
+  and `source`/`source_id` metadata to guarantee idempotency. Returns
+  `{ "success": true, "note_id": "..." }` when created, or
+  `{ "success": true, "duplicate": true, "message": "Note already exists for this source/source_id" }`
+  when the LunaTask API responds with `204 No Content` for duplicates.
 - `update_task`: Updates an existing task by ID. Supports partial updates—only the fields you pass (same set as create, minus the required `name`) are mutated. Returns `{ "success": true, "task": {...} }` with the full serialized task payload.
 - `delete_task`: Permanently deletes a task from LunaTask. Returns `{ "success": true, "task_id": "..." }`. **Deleted tasks cannot be recovered**, so invoke with caution.
 - `track_habit`: Logs habit activity for a specific habit ID and ISO date. Returns `{ "ok": true, "message": "Successfully tracked habit <id> on <date>" }` when the API confirms the event.
@@ -266,7 +271,7 @@ Track progress in [issue #14](https://github.com/tensorfreitas/lunatask-mcp/issu
 - [ ] filters for specific dates
 - [ ] filters for completed tasks in a range of dates
 3. Extra tools
-- [ ] Implement [`create_note` tool](https://lunatask.app/api/notes-api/create)
+- [x] Implement [`create_note` tool](https://lunatask.app/api/notes-api/create)
 - [ ] Implement [`create_entry_journal` tool](https://lunatask.app/api/journal-api/create)
 - [ ] Implement [`create_person` tool](https://lunatask.app/api/people-api/create)
 - [ ] Implement [`delete_person` tool](https://lunatask.app/api/people-api/delete)

--- a/docs/architecture/7-core-workflows.md
+++ b/docs/architecture/7-core-workflows.md
@@ -21,3 +21,31 @@ sequenceDiagram
 ```
 
 ---
+
+## Create Note Workflow
+
+```mermaid
+sequenceDiagram
+    participant ClientApp as Client App (IDE)
+    participant CoreServer as MCP Server (stdio)
+    participant NotesTools as NotesTools Component
+    participant LunaTaskClient as LunaTaskClient
+    participant LunaTaskAPI as LunaTask API
+
+    ClientApp->>+CoreServer: Sends MCP `create_note` request via stdio
+    CoreServer->>+NotesTools: Forwards request to `create_note` tool
+    NotesTools->>+LunaTaskClient: Calls `create_note` with validated payload
+    LunaTaskClient->>+LunaTaskAPI: Makes authenticated POST /v1/notes request
+    alt Duplicate detected (204 No Content)
+        LunaTaskAPI-->>-LunaTaskClient: Returns empty body
+        LunaTaskClient-->>-NotesTools: Returns `None`
+        NotesTools-->>-CoreServer: Formats duplicate success response
+    else Note created
+        LunaTaskAPI-->>-LunaTaskClient: Returns wrapped note payload
+        LunaTaskClient-->>-NotesTools: Returns `NoteResponse`
+        NotesTools-->>-CoreServer: Formats success response with note_id
+    end
+    CoreServer-->>-ClientApp: Sends MCP response via stdio
+```
+
+---

--- a/docs/architecture/8-source-tree.md
+++ b/docs/architecture/8-source-tree.md
@@ -10,7 +10,7 @@ lunatask-mcp/
 │       ├── api/
 │       │   ├── __init__.py
 │       │   ├── client.py              # LunaTaskClient + request orchestration
-│       │   └── models.py              # Pydantic enums/models with TaskSource support
+│       │   └── models.py              # Pydantic enums/models with LunataskSource support
 │       ├── config.py                  # ServerConfig settings + validation
 │       ├── main.py                    # CoreServer bootstrap & cli parsing
 │       ├── rate_limiter.py            # TokenBucketLimiter used by client

--- a/src/lunatask_mcp/api/client.py
+++ b/src/lunatask_mcp/api/client.py
@@ -27,7 +27,7 @@ from lunatask_mcp.api.exceptions import (
     LunaTaskTimeoutError,
     LunaTaskValidationError,
 )
-from lunatask_mcp.api.models import TaskCreate, TaskResponse, TaskUpdate
+from lunatask_mcp.api.models import NoteCreate, NoteResponse, TaskCreate, TaskResponse, TaskUpdate
 from lunatask_mcp.config import ServerConfig
 from lunatask_mcp.rate_limiter import TokenBucketLimiter
 
@@ -564,6 +564,55 @@ class LunaTaskClient:
         else:
             logger.debug("Successfully created task: %s", task.id)
             return task
+
+    async def create_note(self, note_data: NoteCreate) -> NoteResponse | None:
+        """Create a new note in the LunaTask API.
+
+        Args:
+            note_data: NoteCreate object containing note data to create.
+
+        Returns:
+            NoteResponse | None: Created note object from the API, or None when
+            the API returns 204 No Content due to an idempotent duplicate.
+
+        Raises:
+            LunaTaskValidationError: Validation error (422)
+            LunaTaskSubscriptionRequiredError: Subscription required (402)
+            LunaTaskAuthenticationError: Invalid bearer token (401)
+            LunaTaskRateLimitError: Rate limit exceeded (429)
+            LunaTaskServerError: Server error occurred (5xx)
+            LunaTaskServiceUnavailableError: Service unavailable (503)
+            LunaTaskTimeoutError: Request timeout
+            LunaTaskNetworkError: Network connectivity error
+            LunaTaskAPIError: Other API errors
+        """
+
+        json_data = json.loads(note_data.model_dump_json(exclude_none=True))
+
+        response_data = await self.make_request("POST", "notes", data=json_data)
+
+        if not response_data:
+            logger.debug(
+                "Note creation returned no content; assuming duplicate for source/source_id"
+            )
+            return None
+
+        try:
+            note_payload = response_data["note"]
+            note = NoteResponse(**note_payload)
+        except KeyError as error:
+            logger.exception("Failed to extract note from wrapped response format")
+            note_name = json_data.get("name", "unknown")
+            raise LunaTaskAPIError.create_parse_error(
+                "notes", note_name=f"{note_name} - missing 'note' key"
+            ) from error
+        except Exception as error:
+            logger.exception("Failed to parse created note response data")
+            note_name = json_data.get("name", "unknown")
+            raise LunaTaskAPIError.create_parse_error("notes", note_name=note_name) from error
+        else:
+            logger.debug("Successfully created note: %s", note.id)
+            return note
 
     async def update_task(self, task_id: str, update: TaskUpdate) -> TaskResponse:
         """Update an existing task in the LunaTask API.

--- a/src/lunatask_mcp/main.py
+++ b/src/lunatask_mcp/main.py
@@ -31,6 +31,7 @@ from fastmcp import Context, FastMCP
 from lunatask_mcp.api.client import LunaTaskClient
 from lunatask_mcp.config import ServerConfig
 from lunatask_mcp.tools.habits import HabitTools
+from lunatask_mcp.tools.notes import NotesTools
 from lunatask_mcp.tools.tasks import TaskTools
 
 
@@ -93,6 +94,7 @@ class CoreServer:
 
         # Initialize HabitTools
         HabitTools(self.app, lunatask_client)
+        NotesTools(self.app, lunatask_client)
 
     def _setup_signal_handlers(self) -> None:
         """Set up signal handlers for graceful shutdown.

--- a/src/lunatask_mcp/tools/notes.py
+++ b/src/lunatask_mcp/tools/notes.py
@@ -1,0 +1,219 @@
+"""Note management tools for LunaTask MCP integration."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date as date_class
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.server.context import Context as ServerContext
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import (
+    LunaTaskAPIError,
+    LunaTaskAuthenticationError,
+    LunaTaskNetworkError,
+    LunaTaskRateLimitError,
+    LunaTaskServerError,
+    LunaTaskServiceUnavailableError,
+    LunaTaskSubscriptionRequiredError,
+    LunaTaskTimeoutError,
+    LunaTaskValidationError,
+)
+from lunatask_mcp.api.models import NoteCreate
+
+logger = logging.getLogger(__name__)
+
+
+class NotesTools:
+    """Note management tools providing MCP integrations for LunaTask notes."""
+
+    def __init__(self, mcp_instance: FastMCP, lunatask_client: LunaTaskClient) -> None:
+        """Initialize NotesTools with FastMCP instance and LunaTask client."""
+
+        self.mcp = mcp_instance
+        self.lunatask_client = lunatask_client
+        self._register_tools()
+
+    async def create_note_tool(  # noqa: PLR0913, PLR0911, PLR0915, C901
+        self,
+        ctx: ServerContext,
+        notebook_id: str | None = None,
+        name: str | None = None,
+        content: str | None = None,
+        date_on: str | None = None,
+        source: str | None = None,
+        source_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a note in LunaTask with optional duplicate detection."""
+
+        await ctx.info("Creating new note")
+
+        parsed_date: date_class | None = None
+        if date_on is not None:
+            try:
+                parsed_date = date_class.fromisoformat(date_on)
+            except ValueError as error:
+                message = f"Invalid date_on format. Expected YYYY-MM-DD format: {error!s}"
+                await ctx.error(message)
+                logger.warning("Invalid date_on provided for create_note: %s", date_on)
+                return {
+                    "success": False,
+                    "error": "validation_error",
+                    "message": message,
+                }
+
+        note_payload = NoteCreate(
+            notebook_id=notebook_id,
+            name=name,
+            content=content,
+            date_on=parsed_date,
+            source=source,
+            source_id=source_id,
+        )
+
+        try:
+            async with self.lunatask_client as client:
+                note_response = await client.create_note(note_payload)
+
+        except LunaTaskValidationError as error:
+            message = f"Note validation failed: {error}"
+            await ctx.error(message)
+            logger.warning("Note validation error: %s", error)
+            return {
+                "success": False,
+                "error": "validation_error",
+                "message": message,
+            }
+
+        except LunaTaskSubscriptionRequiredError as error:
+            message = f"Subscription required: {error}"
+            await ctx.error(message)
+            logger.warning("Subscription required during note creation: %s", error)
+            return {
+                "success": False,
+                "error": "subscription_required",
+                "message": message,
+            }
+
+        except LunaTaskAuthenticationError as error:
+            message = f"Authentication failed: {error}"
+            await ctx.error(message)
+            logger.warning("Authentication error during note creation: %s", error)
+            return {
+                "success": False,
+                "error": "authentication_error",
+                "message": message,
+            }
+
+        except LunaTaskRateLimitError as error:
+            message = f"Rate limit exceeded: {error}"
+            await ctx.error(message)
+            logger.warning("Rate limit exceeded during note creation: %s", error)
+            return {
+                "success": False,
+                "error": "rate_limit_error",
+                "message": message,
+            }
+
+        except (LunaTaskServerError, LunaTaskServiceUnavailableError) as error:
+            message = f"Server error: {error}"
+            await ctx.error(message)
+            logger.warning("Server error during note creation: %s", error)
+            return {
+                "success": False,
+                "error": "server_error",
+                "message": message,
+            }
+
+        except LunaTaskTimeoutError as error:
+            message = f"Request timeout: {error}"
+            await ctx.error(message)
+            logger.warning("Timeout during note creation: %s", error)
+            return {
+                "success": False,
+                "error": "timeout_error",
+                "message": message,
+            }
+
+        except LunaTaskNetworkError as error:
+            message = f"Network error: {error}"
+            await ctx.error(message)
+            logger.warning("Network error during note creation: %s", error)
+            return {
+                "success": False,
+                "error": "network_error",
+                "message": message,
+            }
+
+        except LunaTaskAPIError as error:
+            message = f"API error: {error}"
+            await ctx.error(message)
+            logger.warning("API error during note creation: %s", error)
+            return {
+                "success": False,
+                "error": "api_error",
+                "message": message,
+            }
+
+        except Exception as error:
+            message = f"Unexpected error creating note: {error}"
+            await ctx.error(message)
+            logger.exception("Unexpected error during note creation")
+            return {
+                "success": False,
+                "error": "unexpected_error",
+                "message": message,
+            }
+
+        if note_response is None:
+            duplicate_message = (
+                "Note already exists for this source/source_id in the provided notebook"
+            )
+            await ctx.info("Note already exists; duplicate create skipped")
+            logger.info("Duplicate note detected for notebook=%s", notebook_id)
+            return {
+                "success": True,
+                "duplicate": True,
+                "message": duplicate_message,
+            }
+
+        await ctx.info(f"Successfully created note {note_response.id}")
+        logger.info("Successfully created note %s", note_response.id)
+        return {
+            "success": True,
+            "note_id": note_response.id,
+            "message": "Note created successfully",
+        }
+
+    def _register_tools(self) -> None:
+        """Register note-related MCP tools with the FastMCP instance."""
+
+        async def _create_note(  # noqa: PLR0913
+            ctx: ServerContext,
+            notebook_id: str | None = None,
+            name: str | None = None,
+            content: str | None = None,
+            date_on: str | None = None,
+            source: str | None = None,
+            source_id: str | None = None,
+        ) -> dict[str, Any]:
+            return await self.create_note_tool(
+                ctx,
+                notebook_id,
+                name,
+                content,
+                date_on,
+                source,
+                source_id,
+            )
+
+        self.mcp.tool(
+            name="create_note",
+            description=(
+                "Create a note in LunaTask. Accepts notebook_id, optional name/content, "
+                "an ISO date_on, and optional source/source_id metadata for duplicate "
+                "detection. Returns note_id or duplicate status."
+            ),
+        )(_create_note)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -12,7 +12,7 @@ from typing import LiteralString, cast
 from pydantic import ValidationError
 from pydantic_core import InitErrorDetails, PydanticCustomError
 
-from lunatask_mcp.api.models import TaskResponse
+from lunatask_mcp.api.models import NoteResponse, TaskResponse
 
 VALID_ESTIMATE_MINUTES = 45
 VALID_PROGRESS_PERCENT = 80
@@ -104,6 +104,45 @@ def create_task_response(  # noqa: PLR0913  # Factory functions need many parame
         previous_status=previous_status,
         progress=progress,
         completed_at=completed_at,
+    )
+
+
+def create_note_response(  # noqa: PLR0913
+    note_id: str = "note-1",
+    notebook_id: str | None = "notebook-123",
+    date_on: date | None = VALID_SCHEDULED_ON,
+    sources: Sequence[dict[str, str | None]] | None = None,
+    source: str | None = None,
+    source_id: str | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+    deleted_at: datetime | None = None,
+) -> NoteResponse:
+    """Create a NoteResponse object with default or provided values."""
+
+    if created_at is None:
+        created_at = datetime(2025, 9, 10, 10, 39, 25, tzinfo=UTC)
+    if updated_at is None:
+        updated_at = datetime(2025, 9, 10, 10, 39, 25, tzinfo=UTC)
+
+    if sources is None:
+        sources_payload: list[dict[str, str | None]] = []
+        if source is not None or source_id is not None:
+            sources_payload.append({"source": source, "source_id": source_id})
+    else:
+        sources_payload = [
+            {"source": payload.get("source"), "source_id": payload.get("source_id")}
+            for payload in sources
+        ]
+
+    return NoteResponse(
+        id=note_id,
+        notebook_id=notebook_id,
+        date_on=date_on,
+        sources=sources_payload,
+        created_at=created_at,
+        updated_at=updated_at,
+        deleted_at=deleted_at,
     )
 
 

--- a/tests/test_api_client_create_note.py
+++ b/tests/test_api_client_create_note.py
@@ -1,0 +1,248 @@
+"""Tests for LunaTaskClient.create_note()."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import (
+    LunaTaskAPIError,
+    LunaTaskAuthenticationError,
+    LunaTaskNetworkError,
+    LunaTaskRateLimitError,
+    LunaTaskServerError,
+    LunaTaskServiceUnavailableError,
+    LunaTaskSubscriptionRequiredError,
+    LunaTaskTimeoutError,
+    LunaTaskValidationError,
+)
+from lunatask_mcp.api.models import NoteCreate, NoteResponse
+from lunatask_mcp.config import ServerConfig
+from tests.test_api_client_common import DEFAULT_API_URL, VALID_TOKEN
+
+
+class TestLunaTaskClientCreateNote:
+    """Test suite for LunaTaskClient.create_note()."""
+
+    @pytest.mark.asyncio
+    async def test_create_note_success_all_fields(self, mocker: MockerFixture) -> None:
+        """Client should deserialize wrapped note response on success."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+
+        note_payload = NoteCreate(
+            notebook_id="notebook-123",
+            name="Weekly review",
+            content="## Notes\n- item",
+            date_on=date(2025, 9, 15),
+            source="evernote",
+            source_id="external-352f",
+        )
+
+        mock_response: dict[str, Any] = {
+            "note": {
+                "id": "note-123",
+                "notebook_id": "notebook-123",
+                "date_on": "2025-09-15",
+                "sources": [
+                    {"source": "evernote", "source_id": "external-352f"},
+                ],
+                "created_at": "2025-09-10T10:39:25Z",
+                "updated_at": "2025-09-10T10:39:25Z",
+                "deleted_at": None,
+            }
+        }
+
+        mock_make_request = mocker.patch.object(client, "make_request", return_value=mock_response)
+
+        result = await client.create_note(note_payload)
+
+        assert isinstance(result, NoteResponse)
+        assert result.id == "note-123"
+        assert result.notebook_id == "notebook-123"
+        assert result.date_on == date(2025, 9, 15)
+        assert result.source == "evernote"
+        assert result.source_id == "external-352f"
+        assert result.created_at == datetime(2025, 9, 10, 10, 39, 25, tzinfo=UTC)
+
+        mock_make_request.assert_called_once_with(
+            "POST",
+            "notes",
+            data={
+                "notebook_id": "notebook-123",
+                "name": "Weekly review",
+                "content": "## Notes\n- item",
+                "date_on": "2025-09-15",
+                "source": "evernote",
+                "source_id": "external-352f",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_note_duplicate_returns_none(self, mocker: MockerFixture) -> None:
+        """204 duplicates should return None to signal no new note was created."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        note_payload = NoteCreate(name="Weekly review")
+
+        mock_make_request = mocker.patch.object(client, "make_request", return_value={})
+
+        result = await client.create_note(note_payload)
+
+        assert result is None
+        mock_make_request.assert_called_once_with("POST", "notes", data={"name": "Weekly review"})
+
+    @pytest.mark.asyncio
+    async def test_create_note_parse_error_missing_note_key(self, mocker: MockerFixture) -> None:
+        """Missing wrapped note should raise a LunaTaskAPIError parse error."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        note_payload = NoteCreate(name="Weekly review")
+
+        mocker.patch.object(client, "make_request", return_value={"unexpected": {}})
+
+        with pytest.raises(LunaTaskAPIError, match="Failed to parse response"):
+            await client.create_note(note_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_note_validation_error(self, mocker: MockerFixture) -> None:
+        """Propagate validation errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        note_payload = NoteCreate(name="Weekly review")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskValidationError("Entity validation failed"),
+        )
+
+        with pytest.raises(LunaTaskValidationError, match="Entity validation failed"):
+            await client.create_note(note_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_note_subscription_required(self, mocker: MockerFixture) -> None:
+        """Propagate subscription required errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        note_payload = NoteCreate(name="Weekly review")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskSubscriptionRequiredError("Upgrade required"),
+        )
+
+        with pytest.raises(LunaTaskSubscriptionRequiredError, match="Upgrade required"):
+            await client.create_note(note_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_note_authentication_error(self, mocker: MockerFixture) -> None:
+        """Propagate authentication errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        note_payload = NoteCreate(name="Weekly review")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskAuthenticationError("Invalid token"),
+        )
+
+        with pytest.raises(LunaTaskAuthenticationError, match="Invalid token"):
+            await client.create_note(note_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_note_rate_limit_error(self, mocker: MockerFixture) -> None:
+        """Propagate rate limit errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        note_payload = NoteCreate(name="Weekly review")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskRateLimitError("Rate limit exceeded"),
+        )
+
+        with pytest.raises(LunaTaskRateLimitError, match="Rate limit exceeded"):
+            await client.create_note(note_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_note_server_error(self, mocker: MockerFixture) -> None:
+        """Propagate server errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        note_payload = NoteCreate(name="Weekly review")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskServerError("Internal error", status_code=500),
+        )
+
+        with pytest.raises(LunaTaskServerError, match="Internal error"):
+            await client.create_note(note_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_note_service_unavailable_error(self, mocker: MockerFixture) -> None:
+        """Propagate service unavailable errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        note_payload = NoteCreate(name="Weekly review")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskServiceUnavailableError("Maintenance"),
+        )
+
+        with pytest.raises(LunaTaskServiceUnavailableError, match="Maintenance"):
+            await client.create_note(note_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_note_timeout_error(self, mocker: MockerFixture) -> None:
+        """Propagate timeout errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        note_payload = NoteCreate(name="Weekly review")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskTimeoutError("Timeout"),
+        )
+
+        with pytest.raises(LunaTaskTimeoutError, match="Timeout"):
+            await client.create_note(note_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_note_network_error(self, mocker: MockerFixture) -> None:
+        """Propagate network errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        note_payload = NoteCreate(name="Weekly review")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskNetworkError("Network error"),
+        )
+
+        with pytest.raises(LunaTaskNetworkError, match="Network error"):
+            await client.create_note(note_payload)

--- a/tests/test_api_models_notes.py
+++ b/tests/test_api_models_notes.py
@@ -1,0 +1,67 @@
+"""Tests for LunaTask note models."""
+
+import json
+from datetime import UTC, date, datetime
+
+from lunatask_mcp.api.models import NoteCreate, NoteResponse
+
+
+def test_note_response_normalizes_legacy_source_fields() -> None:
+    """Ensure legacy source fields are transformed into the sources list."""
+
+    note = NoteResponse(
+        id="note-123",
+        notebook_id="notebook-001",
+        date_on=None,
+        source="evernote",
+        source_id="352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7",
+        created_at=datetime(2025, 9, 10, 10, 39, 25, tzinfo=UTC),
+        updated_at=datetime(2025, 9, 10, 10, 39, 25, tzinfo=UTC),
+        deleted_at=None,
+    )
+
+    assert len(note.sources) == 1
+    source_entry = note.sources[0]
+    assert source_entry.source == "evernote"
+    assert source_entry.source_id == "352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7"
+    assert note.source == "evernote"
+    assert note.source_id == "352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7"
+
+
+def test_note_response_computed_fields_return_none_when_no_sources() -> None:
+    """Computed fields should return None when the payload lacks sources."""
+
+    note = NoteResponse(
+        id="note-789",
+        notebook_id=None,
+        date_on=None,
+        created_at=datetime(2025, 9, 10, 10, 39, 25, tzinfo=UTC),
+        updated_at=datetime(2025, 9, 10, 10, 39, 25, tzinfo=UTC),
+        deleted_at=None,
+    )
+
+    assert note.sources == []
+    assert note.source is None
+    assert note.source_id is None
+
+
+def test_note_create_serializes_date_on_to_iso_string() -> None:
+    """NoteCreate should serialize date_on values to ISO-8601 strings."""
+
+    note_create = NoteCreate(
+        notebook_id="notebook-001",
+        name="Sync planning notes",
+        content="## Plan\n- item 1",
+        date_on=date(2025, 9, 15),
+        source="evernote",
+        source_id="external-123",
+    )
+
+    payload = json.loads(note_create.model_dump_json(exclude_none=True))
+
+    assert payload["notebook_id"] == "notebook-001"
+    assert payload["name"] == "Sync planning notes"
+    assert payload["content"] == "## Plan\n- item 1"
+    assert payload["date_on"] == "2025-09-15"
+    assert payload["source"] == "evernote"
+    assert payload["source_id"] == "external-123"

--- a/tests/test_note_tools_create_note_tool.py
+++ b/tests/test_note_tools_create_note_tool.py
@@ -1,0 +1,186 @@
+"""Tests for NotesTools.create_note_tool()."""
+
+from datetime import UTC, datetime
+
+import pytest
+from fastmcp import FastMCP
+from pydantic import HttpUrl
+from pytest_mock import MockerFixture
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import (
+    LunaTaskAPIError,
+    LunaTaskAuthenticationError,
+    LunaTaskNetworkError,
+    LunaTaskRateLimitError,
+    LunaTaskServerError,
+    LunaTaskServiceUnavailableError,
+    LunaTaskSubscriptionRequiredError,
+    LunaTaskTimeoutError,
+    LunaTaskValidationError,
+)
+from lunatask_mcp.api.models import NoteCreate
+from lunatask_mcp.config import ServerConfig
+from lunatask_mcp.tools.notes import NotesTools
+from tests.factories import create_note_response
+
+
+class TestCreateNoteTool:
+    """Test suite for the create_note MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_create_note_tool_success(self, mocker: MockerFixture) -> None:
+        """Tool should return success payload and note_id on creation."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        notes_tools = NotesTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        created_note = create_note_response(
+            note_id="note-123",
+            notebook_id="notebook-abc",
+            created_at=datetime(2025, 9, 10, 10, 39, 25, tzinfo=UTC),
+            updated_at=datetime(2025, 9, 10, 10, 39, 25, tzinfo=UTC),
+        )
+
+        mocker.patch.object(client, "create_note", return_value=created_note)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await notes_tools.create_note_tool(mock_ctx, name="Weekly review")
+
+        assert result == {
+            "success": True,
+            "note_id": "note-123",
+            "message": "Note created successfully",
+        }
+
+        client.create_note.assert_called_once()  # type: ignore[attr-defined]
+        call_arg = client.create_note.call_args[0][0]  # type: ignore[attr-defined]
+        assert isinstance(call_arg, NoteCreate)
+        assert call_arg.name == "Weekly review"
+
+    @pytest.mark.asyncio
+    async def test_create_note_tool_duplicate(self, mocker: MockerFixture) -> None:
+        """Duplicate detection should return success with duplicate flag."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        notes_tools = NotesTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(client, "create_note", return_value=None)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await notes_tools.create_note_tool(
+            mock_ctx,
+            notebook_id="notebook-xyz",
+            name="Weekly review",
+            source="evernote",
+            source_id="external-123",
+        )
+
+        assert result == {
+            "success": True,
+            "duplicate": True,
+            "message": ("Note already exists for this source/source_id in the provided notebook"),
+        }
+
+    @pytest.mark.asyncio
+    async def test_create_note_tool_invalid_date(self, mocker: MockerFixture) -> None:
+        """Invalid date_on must return structured validation error."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        notes_tools = NotesTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        result = await notes_tools.create_note_tool(
+            mock_ctx, name="Weekly review", date_on="2025/09/15"
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert "Invalid date_on format" in result["message"]
+        mock_ctx.error.assert_awaited_once()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("exception", "error_key"),
+        [
+            (LunaTaskValidationError("Invalid body"), "validation_error"),
+            (LunaTaskSubscriptionRequiredError("Upgrade required"), "subscription_required"),
+            (LunaTaskAuthenticationError("Invalid token"), "authentication_error"),
+            (LunaTaskRateLimitError("Too many requests"), "rate_limit_error"),
+            (LunaTaskServerError("Internal error"), "server_error"),
+            (LunaTaskServiceUnavailableError("Maintenance"), "server_error"),
+            (LunaTaskTimeoutError("Timeout"), "timeout_error"),
+            (LunaTaskNetworkError("Network error"), "network_error"),
+        ],
+    )
+    async def test_create_note_tool_maps_known_exceptions(
+        self, mocker: MockerFixture, exception: Exception, error_key: str
+    ) -> None:
+        """Known exceptions must map to structured MCP error payloads."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        notes_tools = NotesTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(client, "create_note", side_effect=exception)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await notes_tools.create_note_tool(mock_ctx, name="Weekly review")
+
+        assert result["success"] is False
+        assert result["error"] == error_key
+        mock_ctx.error.assert_awaited_once()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_create_note_tool_unexpected_error(self, mocker: MockerFixture) -> None:
+        """Unexpected exceptions should surface as api_error payloads."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        notes_tools = NotesTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(client, "create_note", side_effect=LunaTaskAPIError("Boom"))
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await notes_tools.create_note_tool(mock_ctx, name="Weekly review")
+
+        assert result["success"] is False
+        assert result["error"] == "api_error"
+        assert "Boom" in result["message"]
+        mock_ctx.error.assert_awaited_once()  # type: ignore[attr-defined]

--- a/tests/test_note_tools_create_note_tool_e2e.py
+++ b/tests/test_note_tools_create_note_tool_e2e.py
@@ -1,0 +1,151 @@
+"""End-to-end tests for NotesTools.create_note tool registration."""
+
+import inspect
+
+import pytest
+from fastmcp import FastMCP
+from pydantic import HttpUrl
+from pytest_mock import MockerFixture
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import LunaTaskValidationError
+from lunatask_mcp.config import ServerConfig
+from lunatask_mcp.tools.notes import NotesTools
+from tests.factories import create_note_response
+
+
+class TestCreateNoteToolEndToEnd:
+    """End-to-end validation for create_note MCP tool."""
+
+    def test_create_note_tool_registration(self) -> None:
+        """Tool should be registered with FastMCP and expose expected schema."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+
+        NotesTools(mcp, client)
+
+        tool_manager = mcp._tool_manager  # type: ignore[attr-defined]
+        registered_tools = tool_manager._tools.values()  # type: ignore[attr-defined]
+
+        tool_names = [tool.name for tool in registered_tools]
+        assert "create_note" in tool_names
+
+        create_note_tool = next(tool for tool in registered_tools if tool.name == "create_note")
+        assert create_note_tool.description is not None
+        assert "Create a note" in create_note_tool.description
+
+        try:
+            if hasattr(create_note_tool, "input_schema"):
+                schema = getattr(create_note_tool, "input_schema", None)
+                if isinstance(schema, dict) and "properties" in schema:
+                    properties = schema["properties"]  # type: ignore[index]
+                    expected_params = {
+                        "notebook_id",
+                        "name",
+                        "content",
+                        "date_on",
+                        "source",
+                        "source_id",
+                    }
+                    for param in expected_params:
+                        assert param in properties
+        except (AttributeError, KeyError, TypeError):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_create_note_tool_full_execution_flow(self, mocker: MockerFixture) -> None:
+        """Tool should execute end-to-end and return structured success payload."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        notes_tools = NotesTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        created_note = create_note_response(note_id="note-789", notebook_id="notebook-xyz")
+
+        mocker.patch.object(client, "create_note", return_value=created_note)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await notes_tools.create_note_tool(
+            ctx=mock_ctx,
+            notebook_id="notebook-xyz",
+            name="Weekly review",
+            content="# Heading",
+            date_on="2025-09-15",
+            source="evernote",
+            source_id="external-456",
+        )
+
+        assert result["success"] is True
+        assert result["note_id"] == "note-789"
+        assert result["message"] == "Note created successfully"
+
+        client.create_note.assert_called_once()  # type: ignore[attr-defined]
+        note_arg = client.create_note.call_args[0][0]  # type: ignore[attr-defined]
+        assert note_arg.notebook_id == "notebook-xyz"  # type: ignore[attr-defined]
+        assert note_arg.source == "evernote"  # type: ignore[attr-defined]
+        assert note_arg.source_id == "external-456"  # type: ignore[attr-defined]
+
+        mock_ctx.info.assert_any_call("Creating new note")
+        mock_ctx.info.assert_any_call("Successfully created note note-789")
+
+    @pytest.mark.asyncio
+    async def test_create_note_tool_error_response_format(self, mocker: MockerFixture) -> None:
+        """Tool should return structured error payloads on validation errors."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        notes_tools = NotesTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_note",
+            side_effect=LunaTaskValidationError("Validation failed"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await notes_tools.create_note_tool(mock_ctx, name="Weekly review")
+
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert "Validation failed" in result["message"]
+
+        mock_ctx.error.assert_called_once()
+        error_call = mock_ctx.error.call_args[0][0]
+        assert "Validation failed" in error_call
+
+    def test_create_note_tool_signature(self) -> None:
+        """Function signature should expose expected parameters."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+
+        notes_tools = NotesTools(mcp, client)
+        sig = inspect.signature(notes_tools.create_note_tool)
+        params = list(sig.parameters.keys())
+
+        assert params[0] == "ctx"
+        for expected in ["notebook_id", "name", "content", "date_on", "source", "source_id"]:
+            assert expected in params


### PR DESCRIPTION
## Summary
- Complete implementation of `create_note` MCP tool for LunaTask notes API
- Add comprehensive note models with unified source metadata handling
- Full test coverage and documentation updates

## Core Implementation
- **New Models**: `NoteResponse` and `NoteCreate` with E2E encryption awareness
- **Unified Source Handling**: Refactored `TaskSource` → `LunataskSource` for both tasks and notes
- **Client Method**: `LunaTaskClient.create_note()` with 204 No Content duplicate detection
- **MCP Tool**: `NotesTools` class following established patterns, registered in main.py

## Features
- Support for `notebook_id`, `name`, `content`, `date_on`, `source`/`source_id` parameters
- Idempotent creation using source metadata for duplicate detection
- Structured MCP responses for success, duplicates, and all error conditions
- Full async/await pattern with proper exception mapping
- Rate limiting and retry logic inherited from base client

## Testing
- Comprehensive test coverage: unit, integration, and e2e registration tests
- New test files: api client, models, tool logic, and MCP tool registration
- Added note response factory for test data generation
- Maintains 95%+ coverage baseline

## Documentation
- Updated README.md with `create_note` tool description and E2E encryption notes
- Architecture docs updated: data models, external APIs, core workflows, source tree

## Test plan
- [x] All existing tests continue to pass
- [x] New note creation tests cover success, duplicate, and error scenarios
- [x] Tool registration and MCP schema validation
- [x] Pre-commit hooks pass (ruff, pyright)
- [x] Manual testing of create_note tool via MCP client

Resolves: https://github.com/tensorfreitas/lunatask-mcp/issues/25