### PR TITLE
feat: implement create_journal_entry tool for LunaTask journal API

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ rate_limit_burst = 10
 http_retries = 2
 # Initial retry backoff delay in seconds; doubles with each retry (default: 0.25)
 http_backoff_start_seconds = 0.25
+# Minimum delay before mutating requests (POST/PATCH/DELETE); set to 0.0 to disable (default: 0.0)
+http_min_mutation_interval_seconds = 0.0
 # Custom User-Agent header advertised to the LunaTask API
 http_user_agent = "lunatask-mcp/0.1.0"
 # Timeout in seconds for establishing the TLS connection
@@ -158,7 +160,8 @@ The server validates all configuration on startup and fails fast with clear erro
 The server provides the following tools:
 - **Ping Tool**: A health-check tool that responds with "pong" when called
 - **MCP Resources (read-only)**: Discovery + single task, plus area/global list aliases
-- **MCP Tools (write)**: Create, update, delete tasks; track habit activity
+- **MCP Tools (write)**: Create, update, delete tasks; create notes; create journal entries; track habit
+  activity
 - **MCP Protocol Version**: Supports MCP protocol version `2025-06-18`
 - **Stdio Transport**: Communicates over standard input/output streams
 
@@ -177,6 +180,10 @@ coverage. Clients such as Claude Desktop, Claude Code, Cline, Continue, Roo Code
   `{ "success": true, "note_id": "..." }` when created, or
   `{ "success": true, "duplicate": true, "message": "Note already exists for this source/source_id" }`
   when the LunaTask API responds with `204 No Content` for duplicates.
+- `create_journal_entry`: Creates a journal entry for a specific date. Requires `date_on` in
+  `YYYY-MM-DD` format and supports optional `name` and `content` (Markdown). Returns
+  `{ "success": true, "journal_entry_id": "..." }` when LunaTask returns a wrapped
+  `journal_entry`. Responses never include `name` or `content` because of end-to-end encryption.
 - `update_task`: Updates an existing task by ID. Supports partial updates—only the fields you pass (same set as create, minus the required `name`) are mutated. Returns `{ "success": true, "task": {...} }` with the full serialized task payload.
 - `delete_task`: Permanently deletes a task from LunaTask. Returns `{ "success": true, "task_id": "..." }`. **Deleted tasks cannot be recovered**, so invoke with caution.
 - `track_habit`: Logs habit activity for a specific habit ID and ISO date. Returns `{ "ok": true, "message": "Successfully tracked habit <id> on <date>" }` when the API confirms the event.
@@ -272,7 +279,7 @@ Track progress in [issue #14](https://github.com/tensorfreitas/lunatask-mcp/issu
 - [ ] filters for completed tasks in a range of dates
 3. Extra tools
 - [x] Implement [`create_note` tool](https://lunatask.app/api/notes-api/create)
-- [ ] Implement [`create_entry_journal` tool](https://lunatask.app/api/journal-api/create)
+- [x] Implement [`create_journal_entry` tool](https://lunatask.app/api/journal-api/create)
 - [ ] Implement [`create_person` tool](https://lunatask.app/api/people-api/create)
 - [ ] Implement [`delete_person` tool](https://lunatask.app/api/people-api/delete)
 - [ ] Implement [`create_person_timeline_note` tool](https://lunatask.app/api/person-timeline-notes-api/create)

--- a/docs/architecture/4-data-models.md
+++ b/docs/architecture/4-data-models.md
@@ -250,6 +250,57 @@ class NoteCreate(BaseModel):
     )
 ```
 
+# Journal Entry Models
+
+Journal entries are lightweight diary records that mirror LunaTask's end-to-end encrypted
+storage. The create endpoint accepts optional metadata, but responses only expose structural
+fields. All request parameters are validated through Pydantic models in
+`src/lunatask_mcp/api/models.py`.
+
+### `JournalEntryCreate` (Request Model)
+
+```python
+from datetime import date
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class JournalEntryCreate(BaseModel):
+    """Request payload for creating LunaTask journal entries."""
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+
+    date_on: date = Field(description="Journal entry date (ISO-8601 date string)")
+    name: str | None = Field(default=None, description="Optional journal entry title")
+    content: str | None = Field(
+        default=None,
+        description="Markdown content body for the journal entry",
+    )
+```
+
+### `JournalEntryResponse` (Response Model)
+
+```python
+from datetime import date, datetime
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class JournalEntryResponse(BaseModel):
+    """Response model for LunaTask journal entry data."""
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+
+    id: str = Field(description="Journal entry identifier (UUID)")
+    date_on: date = Field(description="The date the journal entry belongs to")
+    created_at: datetime = Field(description="Creation timestamp")
+    updated_at: datetime = Field(description="Last update timestamp")
+```
+
+**Response Notes**:
+- API responses omit `name` and `content` due to LunaTask's end-to-end encryption guarantees.
+- The top-level payload is wrapped: `{ "journal_entry": { ... } }`. We unwrap that response in
+  `LunaTaskClient.create_journal_entry()` before constructing `JournalEntryResponse`, keeping wrapper
+  handling consistent with the notes client workflow and out of the Pydantic model itself.
+
 ## Habit Models
 
 These models are based on the [Habits API Documentation](https://lunatask.app/api/habits-api/track-activity).

--- a/docs/architecture/7-core-workflows.md
+++ b/docs/architecture/7-core-workflows.md
@@ -49,3 +49,31 @@ sequenceDiagram
 ```
 
 ---
+
+## Daily Journal Workflow
+
+```mermaid
+sequenceDiagram
+    participant ClientApp as Client App (IDE)
+    participant CoreServer as MCP Server (stdio)
+    participant JournalTools as JournalTools Component
+    participant LunaTaskClient as LunaTaskClient
+    participant LunaTaskAPI as LunaTask API
+
+    ClientApp->>+CoreServer: Sends MCP `create_journal_entry` request (date_on, name, content)
+    CoreServer->>+JournalTools: Forwards request to `create_journal_entry` tool
+    JournalTools->>JournalTools: Validates ISO-8601 `date_on` input
+    alt Invalid date format
+        JournalTools-->>-CoreServer: Returns validation_error payload
+        CoreServer-->>-ClientApp: Emits MCP error response via stdio
+    else Valid date
+        JournalTools->>+LunaTaskClient: Calls create_journal_entry with JournalEntryCreate
+        LunaTaskClient->>+LunaTaskAPI: Makes authenticated POST /v1/journal_entries request
+        LunaTaskAPI-->>-LunaTaskClient: Returns wrapped journal entry payload
+        LunaTaskClient-->>-JournalTools: Returns JournalEntryResponse
+        JournalTools-->>-CoreServer: Formats success payload with journal_entry_id
+        CoreServer-->>-ClientApp: Sends MCP success response via stdio
+    end
+```
+
+---

--- a/src/lunatask_mcp/api/models.py
+++ b/src/lunatask_mcp/api/models.py
@@ -362,3 +362,42 @@ class NoteCreate(BaseModel):
         """Pydantic-compatible initializer with permissive typing for tools/tests."""
 
         super().__init__(**data)  # type: ignore[arg-type]
+
+
+class JournalEntryCreate(BaseModel):
+    """Request model for creating journal entries in LunaTask."""
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+
+    date_on: date = Field(description="Journal entry date (ISO-8601 date string)")
+    name: str | None = Field(default=None, description="Optional title for the journal entry")
+    content: str | None = Field(
+        default=None,
+        description="Markdown content body for the journal entry",
+    )
+
+    def __init__(self, **data: object) -> None:
+        """Pydantic-compatible initializer with permissive typing for tools/tests."""
+
+        super().__init__(**data)  # type: ignore[arg-type]
+
+
+class JournalEntryResponse(BaseModel):
+    """Response model for LunaTask journal entry data.
+
+    The LunaTask API wraps journal entry payloads in `{"journal_entry": {...}}`.
+    We intentionally unwrap that response in the client layer (matching notes
+    handling) so the model here only validates the inner payload structure.
+    """
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+
+    id: str = Field(description="Unique identifier of the journal entry (UUID)")
+    date_on: date = Field(description="Date the journal entry belongs to")
+    created_at: datetime = Field(description="Timestamp when the entry was created")
+    updated_at: datetime = Field(description="Timestamp when the entry was last updated")
+
+    def __init__(self, **data: object) -> None:
+        """Pydantic-compatible initializer with permissive typing for tools/tests."""
+
+        super().__init__(**data)  # type: ignore[arg-type]

--- a/src/lunatask_mcp/config.py
+++ b/src/lunatask_mcp/config.py
@@ -76,6 +76,17 @@ class ServerConfig(BaseModel):
         description="HTTP client backoff start time in seconds",
     )
 
+    http_min_mutation_interval_seconds: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=5.0,
+        description=(
+            "Minimum delay between mutating HTTP requests (POST/PATCH/DELETE) in seconds. "
+            "Leave at 0.0 to rely solely on the token bucket rate limiter; increase when "
+            "coordinating with external throttling constraints."
+        ),
+    )
+
     http_user_agent: str = Field(
         default="lunatask-mcp/0.1.0",
         description="HTTP client User-Agent header",

--- a/src/lunatask_mcp/main.py
+++ b/src/lunatask_mcp/main.py
@@ -31,6 +31,7 @@ from fastmcp import Context, FastMCP
 from lunatask_mcp.api.client import LunaTaskClient
 from lunatask_mcp.config import ServerConfig
 from lunatask_mcp.tools.habits import HabitTools
+from lunatask_mcp.tools.journal import JournalTools
 from lunatask_mcp.tools.notes import NotesTools
 from lunatask_mcp.tools.tasks import TaskTools
 
@@ -95,6 +96,7 @@ class CoreServer:
         # Initialize HabitTools
         HabitTools(self.app, lunatask_client)
         NotesTools(self.app, lunatask_client)
+        JournalTools(self.app, lunatask_client)
 
     def _setup_signal_handlers(self) -> None:
         """Set up signal handlers for graceful shutdown.
@@ -242,6 +244,7 @@ def _get_known_config_fields() -> set[str]:
         "rate_limit_burst",
         "http_retries",
         "http_backoff_start_seconds",
+        "http_min_mutation_interval_seconds",
         "http_user_agent",
         "timeout_connect",
         "timeout_read",

--- a/src/lunatask_mcp/tools/journal.py
+++ b/src/lunatask_mcp/tools/journal.py
@@ -1,0 +1,201 @@
+"""Journal tools providing MCP integrations for LunaTask journal entries."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date as date_class
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.server.context import Context as ServerContext
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import (
+    LunaTaskAPIError,
+    LunaTaskAuthenticationError,
+    LunaTaskNetworkError,
+    LunaTaskRateLimitError,
+    LunaTaskServerError,
+    LunaTaskServiceUnavailableError,
+    LunaTaskSubscriptionRequiredError,
+    LunaTaskTimeoutError,
+    LunaTaskValidationError,
+)
+from lunatask_mcp.api.models import JournalEntryCreate
+
+logger = logging.getLogger(__name__)
+
+
+class JournalTools:
+    """MCP tools that create journal entries via the LunaTask API."""
+
+    def __init__(self, mcp_instance: FastMCP, lunatask_client: LunaTaskClient) -> None:
+        """Initialize JournalTools with MCP instance and LunaTask client."""
+
+        self.mcp = mcp_instance
+        self.lunatask_client = lunatask_client
+        self._register_tools()
+
+    # TODO: Refactor to have less return statements
+    async def create_journal_entry_tool(  # noqa: PLR0911, PLR0915, C901
+        self,
+        ctx: ServerContext,
+        *,
+        date_on: str,
+        name: str | None = None,
+        content: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a LunaTask journal entry for the provided date.
+
+        Args:
+            ctx: FastMCP execution context used for structured logging.
+            date_on: ISO-8601 (YYYY-MM-DD) date that the journal entry belongs to.
+            name: Optional title for the journal entry.
+            content: Optional Markdown body for the journal entry.
+
+        Returns:
+            dict[str, Any]: Structured result containing a success flag, optional
+            `journal_entry_id`, and a human-readable message or error details.
+        """
+
+        await ctx.info("Creating journal entry")
+
+        try:
+            parsed_date = date_class.fromisoformat(date_on)
+        except ValueError as error:
+            message = f"Invalid date_on format. Expected YYYY-MM-DD format: {error!s}"
+            await ctx.error(message)
+            logger.warning("Invalid date_on provided for create_journal_entry: %s", date_on)
+            return {
+                "success": False,
+                "error": "validation_error",
+                "message": message,
+            }
+
+        entry_payload = JournalEntryCreate(
+            date_on=parsed_date,
+            name=name,
+            content=content,
+        )
+
+        try:
+            async with self.lunatask_client as client:
+                journal_entry = await client.create_journal_entry(entry_payload)
+        except LunaTaskValidationError as error:
+            message = f"Journal entry validation failed: {error}"
+            await ctx.error(message)
+            logger.warning("Journal entry validation error: %s", error)
+            return {
+                "success": False,
+                "error": "validation_error",
+                "message": message,
+            }
+        except LunaTaskSubscriptionRequiredError as error:
+            message = f"Subscription required: {error}"
+            await ctx.error(message)
+            logger.warning("Subscription required during journal entry creation: %s", error)
+            return {
+                "success": False,
+                "error": "subscription_required",
+                "message": message,
+            }
+        except LunaTaskAuthenticationError as error:
+            message = f"Authentication failed: {error}"
+            await ctx.error(message)
+            logger.warning("Authentication error during journal entry creation: %s", error)
+            return {
+                "success": False,
+                "error": "authentication_error",
+                "message": message,
+            }
+        except LunaTaskRateLimitError as error:
+            message = f"Rate limit exceeded: {error}"
+            await ctx.error(message)
+            logger.warning("Rate limit exceeded during journal entry creation: %s", error)
+            return {
+                "success": False,
+                "error": "rate_limit_error",
+                "message": message,
+            }
+        except (LunaTaskServerError, LunaTaskServiceUnavailableError) as error:
+            message = f"Server error: {error}"
+            await ctx.error(message)
+            logger.warning("Server error during journal entry creation: %s", error)
+            return {
+                "success": False,
+                "error": "server_error",
+                "message": message,
+            }
+        except LunaTaskTimeoutError as error:
+            message = f"Request timeout: {error}"
+            await ctx.error(message)
+            logger.warning("Timeout during journal entry creation: %s", error)
+            return {
+                "success": False,
+                "error": "timeout_error",
+                "message": message,
+            }
+        except LunaTaskNetworkError as error:
+            message = f"Network error: {error}"
+            await ctx.error(message)
+            logger.warning("Network error during journal entry creation: %s", error)
+            return {
+                "success": False,
+                "error": "network_error",
+                "message": message,
+            }
+        except LunaTaskAPIError as error:
+            message = f"API error: {error}"
+            await ctx.error(message)
+            logger.warning("API error during journal entry creation: %s", error)
+            return {
+                "success": False,
+                "error": "api_error",
+                "message": message,
+            }
+        except Exception as error:
+            message = f"Unexpected error creating journal entry: {error}"
+            await ctx.error(message)
+            logger.exception("Unexpected error during journal entry creation")
+            return {
+                "success": False,
+                "error": "unexpected_error",
+                "message": message,
+            }
+
+        await ctx.info(f"Successfully created journal entry {journal_entry.id}")
+        logger.info("Successfully created journal entry %s", journal_entry.id)
+        return {
+            "success": True,
+            "journal_entry_id": journal_entry.id,
+            "message": "Journal entry created successfully",
+        }
+
+    def _register_tools(self) -> None:
+        """Register journal MCP tools with the FastMCP instance.
+
+        Returns:
+            None: This method registers callbacks on the MCP instance in-place.
+        """
+
+        async def _create_journal_entry(
+            ctx: ServerContext,
+            *,
+            date_on: str,
+            name: str | None = None,
+            content: str | None = None,
+        ) -> dict[str, Any]:
+            return await self.create_journal_entry_tool(
+                ctx,
+                date_on=date_on,
+                name=name,
+                content=content,
+            )
+
+        self.mcp.tool(
+            name="create_journal_entry",
+            description=(
+                "Create a journal entry for a specific date. Provide the date in YYYY-MM-DD format"
+                " along with optional name and content fields."
+            ),
+        )(_create_journal_entry)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -12,7 +12,7 @@ from typing import LiteralString, cast
 from pydantic import ValidationError
 from pydantic_core import InitErrorDetails, PydanticCustomError
 
-from lunatask_mcp.api.models import NoteResponse, TaskResponse
+from lunatask_mcp.api.models import JournalEntryResponse, NoteResponse, TaskResponse
 
 VALID_ESTIMATE_MINUTES = 45
 VALID_PROGRESS_PERCENT = 80
@@ -144,6 +144,37 @@ def create_note_response(  # noqa: PLR0913
         updated_at=updated_at,
         deleted_at=deleted_at,
     )
+
+
+def create_journal_entry_response(  # noqa: PLR0913
+    entry_id: str = "journal-entry-1",
+    date_on: date = date(2025, 9, 20),
+    name: str | None = None,
+    content: str | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+) -> JournalEntryResponse:
+    """Create a JournalEntryResponse object with default or provided values."""
+
+    if created_at is None:
+        created_at = datetime(2025, 9, 20, 7, 30, tzinfo=UTC)
+    if updated_at is None:
+        updated_at = datetime(2025, 9, 20, 7, 35, tzinfo=UTC)
+
+    payload = {
+        "id": entry_id,
+        "date_on": date_on,
+        "created_at": created_at,
+        "updated_at": updated_at,
+    }
+
+    # The API omits name/content fields in responses; include only when provided for tests.
+    if name is not None:
+        payload["name"] = name
+    if content is not None:
+        payload["content"] = content
+
+    return JournalEntryResponse(**payload)
 
 
 def build_validation_error(

--- a/tests/test_api_client_create_journal_entry.py
+++ b/tests/test_api_client_create_journal_entry.py
@@ -1,0 +1,247 @@
+"""Tests for LunaTaskClient.create_journal_entry()."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import (
+    LunaTaskAPIError,
+    LunaTaskAuthenticationError,
+    LunaTaskNetworkError,
+    LunaTaskRateLimitError,
+    LunaTaskServerError,
+    LunaTaskServiceUnavailableError,
+    LunaTaskSubscriptionRequiredError,
+    LunaTaskTimeoutError,
+    LunaTaskValidationError,
+)
+from lunatask_mcp.api.models import JournalEntryCreate, JournalEntryResponse
+from lunatask_mcp.config import ServerConfig
+from tests.test_api_client_common import DEFAULT_API_URL, VALID_TOKEN
+
+
+class TestLunaTaskClientCreateJournalEntry:
+    """Test suite for LunaTaskClient.create_journal_entry()."""
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_success(self, mocker: MockerFixture) -> None:
+        """Client should call POST /journal_entries and deserialize wrapped response."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+
+        create_payload = JournalEntryCreate(
+            date_on=date(2025, 9, 20),
+            name="Day review",
+            content="Gratitude list",
+        )
+
+        mock_response: dict[str, Any] = {
+            "journal_entry": {
+                "id": "journal-123",
+                "date_on": "2025-09-20",
+                "created_at": "2025-09-20T07:30:00Z",
+                "updated_at": "2025-09-20T07:30:00Z",
+            }
+        }
+
+        mock_make_request = mocker.patch.object(client, "make_request", return_value=mock_response)
+
+        result = await client.create_journal_entry(create_payload)
+
+        assert isinstance(result, JournalEntryResponse)
+        assert result.id == "journal-123"
+        assert result.date_on == date(2025, 9, 20)
+        assert result.created_at == datetime(2025, 9, 20, 7, 30, tzinfo=UTC)
+        assert result.updated_at == datetime(2025, 9, 20, 7, 30, tzinfo=UTC)
+
+        mock_make_request.assert_called_once_with(
+            "POST",
+            "journal_entries",
+            data={
+                "date_on": "2025-09-20",
+                "name": "Day review",
+                "content": "Gratitude list",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_missing_key_parse_error(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Missing journal_entry wrapper should raise a parse error."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        create_payload = JournalEntryCreate(date_on=date(2025, 9, 20))
+
+        mocker.patch.object(client, "make_request", return_value={"unexpected": {}})
+
+        with pytest.raises(LunaTaskAPIError, match="Failed to parse response"):
+            await client.create_journal_entry(create_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_validation_error(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Propagate validation errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        create_payload = JournalEntryCreate(date_on=date(2025, 9, 20))
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskValidationError("Entity validation failed"),
+        )
+
+        with pytest.raises(LunaTaskValidationError, match="Entity validation failed"):
+            await client.create_journal_entry(create_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_authentication_error(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Propagate authentication errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        create_payload = JournalEntryCreate(date_on=date(2025, 9, 20))
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskAuthenticationError("Invalid token"),
+        )
+
+        with pytest.raises(LunaTaskAuthenticationError, match="Invalid token"):
+            await client.create_journal_entry(create_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_subscription_required(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Propagate subscription required errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        create_payload = JournalEntryCreate(date_on=date(2025, 9, 20))
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskSubscriptionRequiredError("Upgrade required"),
+        )
+
+        with pytest.raises(LunaTaskSubscriptionRequiredError, match="Upgrade required"):
+            await client.create_journal_entry(create_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_rate_limit_error(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Propagate rate limit errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        create_payload = JournalEntryCreate(date_on=date(2025, 9, 20))
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskRateLimitError("Rate limit exceeded"),
+        )
+
+        with pytest.raises(LunaTaskRateLimitError, match="Rate limit exceeded"):
+            await client.create_journal_entry(create_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_server_error(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Propagate server errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        create_payload = JournalEntryCreate(date_on=date(2025, 9, 20))
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskServerError("Internal error", status_code=500),
+        )
+
+        with pytest.raises(LunaTaskServerError, match="Internal error"):
+            await client.create_journal_entry(create_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_service_unavailable_error(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Propagate service unavailable errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        create_payload = JournalEntryCreate(date_on=date(2025, 9, 20))
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskServiceUnavailableError("Maintenance"),
+        )
+
+        with pytest.raises(LunaTaskServiceUnavailableError, match="Maintenance"):
+            await client.create_journal_entry(create_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_timeout_error(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Propagate timeout errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        create_payload = JournalEntryCreate(date_on=date(2025, 9, 20))
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskTimeoutError("Timeout"),
+        )
+
+        with pytest.raises(LunaTaskTimeoutError, match="Timeout"):
+            await client.create_journal_entry(create_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_network_error(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Propagate network errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        create_payload = JournalEntryCreate(date_on=date(2025, 9, 20))
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskNetworkError("Network error"),
+        )
+
+        with pytest.raises(LunaTaskNetworkError, match="Network error"):
+            await client.create_journal_entry(create_payload)

--- a/tests/test_api_models_journal.py
+++ b/tests/test_api_models_journal.py
@@ -1,0 +1,80 @@
+"""Tests for LunaTask journal entry models."""
+
+import json
+from datetime import UTC, date, datetime
+
+from lunatask_mcp.api.models import JournalEntryCreate, JournalEntryResponse
+
+
+def test_journal_entry_create_serializes_date_on_to_iso_string() -> None:
+    """`JournalEntryCreate` should serialize date fields to ISO-8601 strings."""
+
+    journal_entry = JournalEntryCreate(
+        date_on=date(2025, 9, 21),
+        name="Daily reflection",
+        content="## Highlights\n- Wrapped up MCP tool plan",
+    )
+
+    payload = json.loads(journal_entry.model_dump_json(exclude_none=True))
+
+    assert payload["date_on"] == "2025-09-21"
+    assert payload["name"] == "Daily reflection"
+    assert payload["content"] == "## Highlights\n- Wrapped up MCP tool plan"
+
+
+def test_journal_entry_create_with_required_fields_serializes_minimal_payload() -> None:
+    """Minimal payload should include only the required date_on field."""
+
+    journal_entry = JournalEntryCreate(date_on=date(2025, 9, 21))
+
+    payload = json.loads(journal_entry.model_dump_json(exclude_none=True))
+
+    assert payload == {"date_on": "2025-09-21"}
+
+
+def test_journal_entry_response_parses_datetimes_from_unwrapped_payload() -> None:
+    """`JournalEntryResponse` should parse datetime fields from unwrapped payloads."""
+
+    response_payload = {
+        "id": "journal-123",
+        "date_on": "2025-09-20",
+        "created_at": "2025-09-20T10:39:25Z",
+        "updated_at": "2025-09-20T11:10:05Z",
+    }
+
+    journal_entry = JournalEntryResponse.model_validate(response_payload)
+
+    assert journal_entry.id == "journal-123"
+    assert journal_entry.date_on == date(2025, 9, 20)
+    assert journal_entry.created_at == datetime(2025, 9, 20, 10, 39, 25, tzinfo=UTC)
+    assert journal_entry.updated_at == datetime(2025, 9, 20, 11, 10, 5, tzinfo=UTC)
+
+
+def test_journal_entry_response_does_not_expose_encrypted_fields() -> None:
+    """Responses should not expose encrypted fields like `name` or `content`."""
+
+    journal_entry = JournalEntryResponse(
+        id="journal-456",
+        date_on=date(2025, 9, 19),
+        created_at=datetime(2025, 9, 19, 6, 0, 0, tzinfo=UTC),
+        updated_at=datetime(2025, 9, 19, 6, 0, 0, tzinfo=UTC),
+    )
+
+    assert not hasattr(journal_entry, "name")
+    assert not hasattr(journal_entry, "content")
+
+
+def test_journal_entry_response_accepts_minimal_unwrapped_payload() -> None:
+    """Minimal unwrapped payloads should parse when only required fields are present."""
+
+    journal_entry = JournalEntryResponse.model_validate(
+        {
+            "id": "journal-789",
+            "date_on": "2025-09-18",
+            "created_at": "2025-09-18T09:00:00Z",
+            "updated_at": "2025-09-18T09:15:00Z",
+        }
+    )
+
+    assert journal_entry.id == "journal-789"
+    assert journal_entry.date_on == date(2025, 9, 18)

--- a/tests/test_factories_journal.py
+++ b/tests/test_factories_journal.py
@@ -1,0 +1,41 @@
+"""Tests for journal entry factories used in test suite."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+from lunatask_mcp.api.models import JournalEntryResponse
+from tests.factories import create_journal_entry_response
+
+
+class TestCreateJournalEntryResponse:
+    """Unit tests for create_journal_entry_response factory."""
+
+    def test_returns_default_journal_entry_response(self) -> None:
+        """Factory should produce a JournalEntryResponse with default values."""
+
+        result = create_journal_entry_response()
+
+        assert isinstance(result, JournalEntryResponse)
+        assert result.id == "journal-entry-1"
+        assert result.date_on == date(2025, 9, 20)
+        assert result.created_at == datetime(2025, 9, 20, 7, 30, tzinfo=UTC)
+        assert result.updated_at == datetime(2025, 9, 20, 7, 35, tzinfo=UTC)
+
+    def test_supports_custom_field_overrides(self) -> None:
+        """Factory should honor provided field overrides."""
+
+        created_at = datetime(2025, 9, 19, 6, 0, tzinfo=UTC)
+        updated_at = datetime(2025, 9, 19, 6, 5, tzinfo=UTC)
+
+        result = create_journal_entry_response(
+            entry_id="journal-entry-99",
+            date_on=date(2025, 9, 19),
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+        assert result.id == "journal-entry-99"
+        assert result.date_on == date(2025, 9, 19)
+        assert result.created_at is created_at
+        assert result.updated_at is updated_at

--- a/tests/test_journal_tools_create_entry_tool_e2e.py
+++ b/tests/test_journal_tools_create_entry_tool_e2e.py
@@ -1,0 +1,308 @@
+"""End-to-end tests for JournalTools.create_journal_entry tool."""
+
+from __future__ import annotations
+
+import inspect
+from datetime import date
+from unittest.mock import AsyncMock
+
+import pytest
+from fastmcp import FastMCP
+from fastmcp.server.context import Context as ServerContext
+from pydantic import HttpUrl
+from pytest_mock import MockerFixture
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import (
+    LunaTaskAPIError,
+    LunaTaskAuthenticationError,
+    LunaTaskNetworkError,
+    LunaTaskRateLimitError,
+    LunaTaskServerError,
+    LunaTaskServiceUnavailableError,
+    LunaTaskSubscriptionRequiredError,
+    LunaTaskTimeoutError,
+    LunaTaskValidationError,
+)
+from lunatask_mcp.api.models import JournalEntryCreate
+from lunatask_mcp.config import ServerConfig
+from lunatask_mcp.tools.journal import JournalTools
+from tests.factories import create_journal_entry_response
+
+
+class TestCreateJournalEntryToolEndToEnd:
+    """End-to-end validation for create_journal_entry MCP tool."""
+
+    def _build_tools(self) -> tuple[FastMCP, LunaTaskClient, JournalTools]:
+        """Create configured MCP, client, and tool instances for tests."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        tools = JournalTools(mcp, client)
+        return mcp, client, tools
+
+    def test_create_journal_entry_tool_registration(self) -> None:
+        """Tool should register with FastMCP and expose expected schema."""
+
+        mcp, _client, _tools = self._build_tools()
+
+        tool_manager = mcp._tool_manager  # type: ignore[attr-defined]
+        registered_tools = tool_manager._tools.values()  # type: ignore[attr-defined]
+
+        tool_names = [tool.name for tool in registered_tools]
+        assert "create_journal_entry" in tool_names
+
+        create_entry_tool = next(
+            tool for tool in registered_tools if tool.name == "create_journal_entry"
+        )
+        assert create_entry_tool.description is not None
+        assert "Create a journal entry" in create_entry_tool.description
+
+        try:
+            if hasattr(create_entry_tool, "input_schema"):
+                schema = getattr(create_entry_tool, "input_schema", None)
+                if isinstance(schema, dict) and "properties" in schema:
+                    properties = schema["properties"]  # type: ignore[index]
+                    for param in ["date_on", "name", "content"]:
+                        assert param in properties
+        except (AttributeError, KeyError, TypeError):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_tool_success(self, mocker: MockerFixture) -> None:
+        """Tool should execute and return structured success payload."""
+
+        _mcp, client, tools = self._build_tools()
+        mock_ctx = mocker.AsyncMock(spec=ServerContext)
+
+        journal_entry = create_journal_entry_response(entry_id="journal-abc")
+
+        create_entry_mock: AsyncMock = mocker.AsyncMock(return_value=journal_entry)
+        mocker.patch.object(client, "create_journal_entry", create_entry_mock)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await tools.create_journal_entry_tool(
+            ctx=mock_ctx,
+            date_on="2025-09-20",
+            name="Daily reflection",
+            content="Today was productive.",
+        )
+
+        assert result["success"] is True
+        assert result["journal_entry_id"] == "journal-abc"
+        assert result["message"] == "Journal entry created successfully"
+
+        create_entry_mock.assert_awaited_once()
+        await_args = create_entry_mock.await_args
+        assert await_args is not None
+        payload = await_args.args[0]
+        assert isinstance(payload, JournalEntryCreate)
+        assert payload.date_on == date.fromisoformat("2025-09-20")
+        assert payload.name == "Daily reflection"
+        assert payload.content == "Today was productive."
+
+        mock_ctx.info.assert_any_call("Creating journal entry")
+        mock_ctx.info.assert_any_call("Successfully created journal entry journal-abc")
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_tool_invalid_date(self, mocker: MockerFixture) -> None:
+        """Invalid ISO dates should produce validation error payloads."""
+
+        _mcp, client, tools = self._build_tools()
+        mock_ctx = mocker.AsyncMock(spec=ServerContext)
+
+        mock_create = mocker.patch.object(client, "create_journal_entry", mocker.AsyncMock())
+
+        result = await tools.create_journal_entry_tool(
+            ctx=mock_ctx,
+            date_on="20-09-2025",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert "Invalid date_on format" in result["message"]
+
+        mock_ctx.error.assert_called_once()
+        assert mock_create.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_tool_validation_error(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Tool should surface API validation errors in structured format."""
+
+        _mcp, client, tools = self._build_tools()
+        mock_ctx = mocker.AsyncMock(spec=ServerContext)
+
+        mocker.patch.object(
+            client,
+            "create_journal_entry",
+            side_effect=LunaTaskValidationError("Payload invalid"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await tools.create_journal_entry_tool(
+            ctx=mock_ctx,
+            date_on="2025-09-20",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert "Payload invalid" in result["message"]
+        mock_ctx.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_tool_subscription_required(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        """Tool should map subscription errors to subscription_required."""
+
+        _mcp, client, tools = self._build_tools()
+        mock_ctx = mocker.AsyncMock(spec=ServerContext)
+
+        mocker.patch.object(
+            client,
+            "create_journal_entry",
+            side_effect=LunaTaskSubscriptionRequiredError("Upgrade required"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await tools.create_journal_entry_tool(
+            ctx=mock_ctx,
+            date_on="2025-09-20",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "subscription_required"
+        assert "Upgrade required" in result["message"]
+        mock_ctx.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("exception", "error_key"),
+        [
+            (LunaTaskAuthenticationError("Invalid token"), "authentication_error"),
+            (LunaTaskRateLimitError("Too many requests"), "rate_limit_error"),
+            (LunaTaskServerError("Internal error"), "server_error"),
+            (LunaTaskServiceUnavailableError("Maintenance"), "server_error"),
+            (LunaTaskTimeoutError("Request timed out"), "timeout_error"),
+            (LunaTaskNetworkError("Network unreachable"), "network_error"),
+            (LunaTaskAPIError("API failure"), "api_error"),
+        ],
+    )
+    async def test_create_journal_entry_tool_maps_additional_errors(
+        self,
+        mocker: MockerFixture,
+        exception: Exception,
+        error_key: str,
+    ) -> None:
+        """Tool should map remaining LunaTask errors to structured responses."""
+
+        _mcp, client, tools = self._build_tools()
+        mock_ctx = mocker.AsyncMock(spec=ServerContext)
+
+        mocker.patch.object(
+            client,
+            "create_journal_entry",
+            mocker.AsyncMock(side_effect=exception),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await tools.create_journal_entry_tool(
+            ctx=mock_ctx,
+            date_on="2025-09-20",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == error_key
+        assert str(exception) in result["message"]
+        mock_ctx.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_registered_journal_tool_delegates(self, mocker: MockerFixture) -> None:
+        """Registered FastMCP tool should delegate to create_journal_entry_tool."""
+
+        mcp, client, _tools = self._build_tools()
+        mock_ctx = mocker.AsyncMock(spec=ServerContext)
+
+        journal_entry = create_journal_entry_response(entry_id="journal-wrapper")
+
+        mocker.patch.object(
+            client,
+            "create_journal_entry",
+            mocker.AsyncMock(return_value=journal_entry),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        tool_manager = mcp._tool_manager  # type: ignore[attr-defined]
+        registered_tool = next(
+            tool
+            for tool in tool_manager._tools.values()  # type: ignore[attr-defined]
+            if tool.name == "create_journal_entry"
+        )
+
+        result = await registered_tool.fn(  # type: ignore[call-arg]
+            ctx=mock_ctx,
+            date_on="2025-09-21",
+            name="Wrapper",
+            content="Delegated call",
+        )
+
+        assert result["success"] is True
+        assert result["journal_entry_id"] == "journal-wrapper"
+        mock_ctx.info.assert_any_call("Successfully created journal entry journal-wrapper")
+
+    @pytest.mark.asyncio
+    async def test_create_journal_entry_tool_unexpected_error(self, mocker: MockerFixture) -> None:
+        """Unexpected exceptions should map to unexpected_error payloads."""
+
+        _mcp, client, tools = self._build_tools()
+        mock_ctx = mocker.AsyncMock(spec=ServerContext)
+
+        mock_logger = mocker.patch("lunatask_mcp.tools.journal.logger")
+
+        mocker.patch.object(
+            client,
+            "create_journal_entry",
+            mocker.AsyncMock(side_effect=RuntimeError("Disk failure")),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await tools.create_journal_entry_tool(
+            ctx=mock_ctx,
+            date_on="2025-09-20",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "unexpected_error"
+        assert "Unexpected error creating journal entry" in result["message"]
+        assert "Disk failure" in result["message"]
+
+        mock_ctx.error.assert_called_once()
+        mock_logger.exception.assert_called_once_with(
+            "Unexpected error during journal entry creation"
+        )
+
+    def test_create_journal_entry_tool_signature(self) -> None:
+        """Tool signature should expose context-first parameters."""
+
+        _mcp, _client, tools = self._build_tools()
+        signature = inspect.signature(tools.create_journal_entry_tool)
+        params = list(signature.parameters.keys())
+
+        assert params[0] == "ctx"
+        assert "date_on" in params
+        assert "name" in params
+        assert "content" in params

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -198,6 +198,18 @@ class TestCoreServerLunaTaskIntegration:
         mock_app_run.assert_called_once_with(transport="stdio")
 
 
+def test_core_server_registers_journal_tool(default_config: ServerConfig) -> None:
+    """CoreServer should register the create_journal_entry tool with FastMCP."""
+
+    server = CoreServer(default_config)
+
+    tool_manager = server.app._tool_manager  # type: ignore[attr-defined]
+    registered_tools = tool_manager._tools.values()  # type: ignore[attr-defined]
+    tool_names = {tool.name for tool in registered_tools}
+
+    assert "create_journal_entry" in tool_names
+
+
 class TestCoreServerTaskToolsIntegration:
     """Test CoreServer integration with TaskTools."""
 

--- a/tests/test_stdio_update_task_rate_limit.py
+++ b/tests/test_stdio_update_task_rate_limit.py
@@ -10,9 +10,9 @@ from fastmcp import Client
 from fastmcp.client.transports import StdioTransport
 
 # Constants for rate limiting tests
-# The client enforces ~0.12s stabilization delay on mutating requests
-# (POST/PATCH/DELETE). Use a slightly lower threshold to account for
-# scheduling variance while still catching missing rate limiting.
+# Configure a 120ms stabilization delay via http_min_mutation_interval_seconds.
+# Use a slightly lower threshold to account for scheduling variance while still
+# catching missing rate limiting when the delay is enabled.
 MIN_REQUEST_TIME = 0.11
 MAX_TIMING_VARIANCE = 10.0
 
@@ -34,6 +34,7 @@ port = 8080
 log_level = "DEBUG"
 http_retries = 0
 http_backoff_start_seconds = 0.1
+http_min_mutation_interval_seconds = 0.12
 timeout_connect = 1.0
 timeout_read = 5.0
 """


### PR DESCRIPTION
## Summary

Implements the `create_journal_entry` MCP tool that creates daily journal entries via LunaTask's Journal API.

- **New Models**: `JournalEntryCreate` and `JournalEntryResponse` with proper Pydantic validation
- **API Client**: `LunaTaskClient.create_journal_entry()` method with wrapped response handling
- **MCP Tool**: `JournalTools.create_journal_entry_tool()` with structured success/error responses
- **Configuration**: Added `http_min_mutation_interval_seconds` for API pacing control
- **Testing**: Comprehensive unit, integration, and e2e test coverage (95%+ coverage maintained)
- **Documentation**: Updated API docs, data models, and workflow diagrams

## Key Features

- Date validation with clear error messages for invalid ISO-8601 formats
- Optional `name` and `content` fields for journal entry metadata
- Mirrors error handling patterns from existing `create_note` tool
- End-to-end encryption support (responses omit sensitive fields)
- Proper rate limiting and mutation interval handling

## Test Coverage

- Unit tests for Pydantic models and serialization
- API client tests with comprehensive error scenario coverage
- End-to-end tool tests validating MCP registration and execution
- Factory methods for test data generation

## Documentation Updates

- `README.md`: Added tool description and usage example
- `docs/architecture/4-data-models.md`: Journal entry model specifications
- `docs/architecture/6-external-apis.md`: API endpoint documentation
- `docs/architecture/7-core-workflows.md`: Journal workflow sequence diagram

Closes #26