### PR TITLE
feat: implement create_person_timeline_note tool (fixes #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ coverage. Clients such as Claude Desktop, Claude Code, Cline, Continue, Roo Code
   `{ "success": true, "journal_entry_id": "..." }` when LunaTask returns a wrapped
   `journal_entry`. Responses never include `name` or `content` because of end-to-end encryption.
 - `create_person`: Creates a new person/contact. Requires `first_name` and `last_name`. Optional fields include `relationship_strength` (one of `family`, `intimate-friends`, `close-friends`, `casual-friends`, `acquaintances`, `business-contacts`, or `almost-strangers`; defaults to `casual-friends`), external source metadata (`source`, `source_id`), and contact details (`email`, `birthday`, `phone`). Returns `{ "success": true, "person_id": "..." }` when created, or `{ "success": true, "duplicate": true, "message": "Person already exists for this source/source_id" }` when LunaTask responds with `204 No Content` for duplicates. Note: Custom fields for email, birthday, or phone must be defined in the LunaTask app first, otherwise returns a 422 validation error.
+- `create_person_timeline_note`: Creates a timeline note for an existing person. Requires `person_id` and `content`, accepts an optional `date` (`YYYY-MM-DD`). When `date` is omitted the LunaTask API stores the note against the current day. Returns `{ "success": true, "person_timeline_note_id": "..." }` on success. Validation, authentication, subscription, rate limit, timeout, and network errors map to structured error payloads, and invalid ISO dates are rejected client-side before hitting the API.
 - `update_task`: Updates an existing task by ID. Supports partial updates—only the fields you pass (same set as create, minus the required `name`) are mutated. Returns `{ "success": true, "task": {...} }` with the full serialized task payload.
 - `delete_task`: Permanently deletes a task from LunaTask. Returns `{ "success": true, "task_id": "..." }`. **Deleted tasks cannot be recovered**, so invoke with caution.
 - `track_habit`: Logs habit activity for a specific habit ID and ISO date. Returns `{ "ok": true, "message": "Successfully tracked habit <id> on <date>" }` when the API confirms the event.
@@ -275,7 +276,7 @@ Track progress in [issue #14](https://github.com/tensorfreitas/lunatask-mcp/issu
 - [ ] resource filters by `goal_id`
 - [ ] filters for all priority types
 - [ ] filters for all motivation types
-- [ ] filters for all eisenhower types
+- [ ] filters for all Eisenhower types
 - [ ] filters for specific dates
 - [ ] filters for completed tasks in a range of dates
 3. Extra tools
@@ -283,7 +284,7 @@ Track progress in [issue #14](https://github.com/tensorfreitas/lunatask-mcp/issu
 - [x] Implement [`create_journal_entry` tool](https://lunatask.app/api/journal-api/create)
 - [x] Implement [`create_person` tool](https://lunatask.app/api/people-api/create)
 - [ ] Implement [`delete_person` tool](https://lunatask.app/api/people-api/delete)
-- [ ] Implement [`create_person_timeline_note` tool](https://lunatask.app/api/person-timeline-notes-api/create)
+- [x] Implement [`create_person_timeline_note` tool](https://lunatask.app/api/person-timeline-notes-api/create)
 4. Extra Resources
 - [ ] Implement [Retrieve person](https://lunatask.app/api/person-timeline-notes-api/create) resource
 - [ ] Implement [Retrieve all people](https://lunatask.app/api/people-api/list) resource

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ coverage. Clients such as Claude Desktop, Claude Code, Cline, Continue, Roo Code
   `YYYY-MM-DD` format and supports optional `name` and `content` (Markdown). Returns
   `{ "success": true, "journal_entry_id": "..." }` when LunaTask returns a wrapped
   `journal_entry`. Responses never include `name` or `content` because of end-to-end encryption.
+- `create_person`: Creates a new person/contact. Requires `first_name` and `last_name`. Optional fields include `relationship_strength` (one of `family`, `intimate-friends`, `close-friends`, `casual-friends`, `acquaintances`, `business-contacts`, or `almost-strangers`; defaults to `casual-friends`), external source metadata (`source`, `source_id`), and contact details (`email`, `birthday`, `phone`). Returns `{ "success": true, "person_id": "..." }` when created, or `{ "success": true, "duplicate": true, "message": "Person already exists for this source/source_id" }` when LunaTask responds with `204 No Content` for duplicates. Note: Custom fields for email, birthday, or phone must be defined in the LunaTask app first, otherwise returns a 422 validation error.
 - `update_task`: Updates an existing task by ID. Supports partial updates—only the fields you pass (same set as create, minus the required `name`) are mutated. Returns `{ "success": true, "task": {...} }` with the full serialized task payload.
 - `delete_task`: Permanently deletes a task from LunaTask. Returns `{ "success": true, "task_id": "..." }`. **Deleted tasks cannot be recovered**, so invoke with caution.
 - `track_habit`: Logs habit activity for a specific habit ID and ISO date. Returns `{ "ok": true, "message": "Successfully tracked habit <id> on <date>" }` when the API confirms the event.
@@ -280,7 +281,7 @@ Track progress in [issue #14](https://github.com/tensorfreitas/lunatask-mcp/issu
 3. Extra tools
 - [x] Implement [`create_note` tool](https://lunatask.app/api/notes-api/create)
 - [x] Implement [`create_journal_entry` tool](https://lunatask.app/api/journal-api/create)
-- [ ] Implement [`create_person` tool](https://lunatask.app/api/people-api/create)
+- [x] Implement [`create_person` tool](https://lunatask.app/api/people-api/create)
 - [ ] Implement [`delete_person` tool](https://lunatask.app/api/people-api/delete)
 - [ ] Implement [`create_person_timeline_note` tool](https://lunatask.app/api/person-timeline-notes-api/create)
 4. Extra Resources

--- a/docs/architecture/5-components.md
+++ b/docs/architecture/5-components.md
@@ -21,6 +21,7 @@ The application will be structured around a few key logical components, each wit
   - **`NotesClientMixin`** (`client_notes.py`): Note creation with 204 No Content handling
   - **`JournalClientMixin`** (`client_journal.py`): Journal entry creation
   - **`HabitsClientMixin`** (`client_habits.py`): Habit tracking functionality
+  - **`PeopleClientMixin`** (`client_people.py`): People/contact creation with duplicate handling
 
 - **`BaseClientProtocol`** (`protocols.py`): Typing protocol enabling mixins to reference base client methods without circular imports, supporting strict pyright type checking
 
@@ -35,6 +36,7 @@ The application will be structured around a few key logical components, each wit
 *   `async def delete_task(task_id: str) -> bool`
 *   `async def create_note(note_data: NoteCreate) -> NoteResponse | None`
 *   `async def create_journal_entry(entry_data: JournalEntryCreate) -> JournalEntryResponse`
+*   `async def create_person(person_data: PersonCreate) -> PersonResponse | None`
 *   `async def track_habit(habit_id: str, track_date: date) -> None`
 *   `async def test_connectivity() -> bool`
 
@@ -90,14 +92,24 @@ This architecture aligns with the stated dependency injection and repository pat
 
 **Dependencies**: `LunaTaskClient`, `fastmcp`.
 
-## 4. `CoreServer` (Application Runner)
+## 4. `PeopleTools` (MCP Interface Component)
+
+**Responsibility**: This component exposes People/Contact functionality to clients by defining MCP **tools** for person creation and management.
+
+**Key Interfaces (as MCP Tools)**:
+
+*   **Tool**: `create_person(first_name: str, last_name: str, ...)` (Calls `LunaTaskClient.create_person`)
+
+**Dependencies**: `LunaTaskClient`, `fastmcp`.
+
+## 5. `CoreServer` (Application Runner)
 
 **Responsibility**: This is the main application entry point (`main.py`). It will be responsible for:
 *   Initializing the `FastMCP` application.
 *   Handling configuration loading (from files and command-line arguments).
 *   Setting up logging to `stderr`.
 *   Initializing the `LunaTaskClient` and making it available to the tool components (e.g., via dependency injection).
-*   Registering the `TaskTools`, `HabitTools`, and a built-in `ping` health-check tool with the FastMCP instance.
+*   Registering the `TaskTools`, `HabitTools`, `PeopleTools`, and a built-in `ping` health-check tool with the FastMCP instance.
 *   Starting the server with the `stdio` transport.
 
 **Dependencies**: All other components.

--- a/docs/architecture/6-external-apis.md
+++ b/docs/architecture/6-external-apis.md
@@ -274,3 +274,17 @@ The `status` parameter supports both individual LunaTask statuses and a special 
 **Implementation Note:** When `status=open` is requested, the MCP server fetches all tasks from the upstream API and applies the composite filter locally, excluding only tasks with `status=completed`.
 
 ---
+
+
+### People Timeline Notes API
+
+#### Implemented Endpoints
+
+1. **POST /v1/person_timeline_notes** - Create Person Timeline Note
+   - **Purpose**: Capture timeline notes for a specific person, optionally backdated.
+   - **Implementation**: `LunaTaskClient.create_person_timeline_note(payload: PersonTimelineNoteCreate)`
+   - **MCP Tool**: `create_person_timeline_note` (handler in `tools/people.py`)
+   - **Request Model**: `PersonTimelineNoteCreate` with fields `person_id`, optional `content`, optional `date_on`.
+   - **Response Model**: `PersonTimelineNoteResponse` parsed from the wrapped response key `person_timeline_note`.
+   - **Behavior**: Omits `content` and `date_on` when `None`; defaults `date_on` server-side to current date when omitted.
+   - **Error Handling**: Raises validation, subscription, authentication, rate limit, service, timeout, network, and API parse errors via custom exceptions.

--- a/docs/architecture/8-source-tree.md
+++ b/docs/architecture/8-source-tree.md
@@ -13,6 +13,7 @@ lunatask-mcp/
 │       │   ├── client_base.py         # BaseClient HTTP infrastructure + auth + retries
 │       │   ├── client_tasks.py        # TasksClientMixin (CRUD operations)
 │       │   ├── client_notes.py        # NotesClientMixin (note creation)
+│       │   ├── client_person_timeline_notes.py  # PersonTimelineNotesClientMixin (create)
 │       │   ├── client_journal.py      # JournalClientMixin (journal entries)
 │       │   ├── client_habits.py       # HabitsClientMixin (habit tracking)
 │       │   ├── protocols.py           # BaseClientProtocol for mixin typing
@@ -29,6 +30,7 @@ lunatask-mcp/
 │           ├── tasks_create.py        # create_task handler (coercion & validation)
 │           ├── tasks_update.py        # update_task handler (partial updates)
 │           ├── tasks_delete.py        # delete_task handler
+│           ├── people.py             # PeopleTools (create person & timeline notes)
 │           └── tasks_resources.py     # Discovery, list, alias & single task resources
 ├── tests/
 │   ├── conftest.py, factories.py      # Function-scoped fixtures and builders

--- a/src/lunatask_mcp/api/client.py
+++ b/src/lunatask_mcp/api/client.py
@@ -11,6 +11,7 @@ from lunatask_mcp.api.client_habits import HabitsClientMixin
 from lunatask_mcp.api.client_journal import JournalClientMixin
 from lunatask_mcp.api.client_notes import NotesClientMixin
 from lunatask_mcp.api.client_people import PeopleClientMixin
+from lunatask_mcp.api.client_person_timeline_notes import PersonTimelineNotesClientMixin
 from lunatask_mcp.api.client_tasks import TasksClientMixin
 
 
@@ -18,6 +19,7 @@ class LunaTaskClient(
     BaseClient,
     TasksClientMixin,
     NotesClientMixin,
+    PersonTimelineNotesClientMixin,
     JournalClientMixin,
     HabitsClientMixin,
     PeopleClientMixin,

--- a/src/lunatask_mcp/api/client.py
+++ b/src/lunatask_mcp/api/client.py
@@ -10,6 +10,7 @@ from lunatask_mcp.api.client_base import BaseClient
 from lunatask_mcp.api.client_habits import HabitsClientMixin
 from lunatask_mcp.api.client_journal import JournalClientMixin
 from lunatask_mcp.api.client_notes import NotesClientMixin
+from lunatask_mcp.api.client_people import PeopleClientMixin
 from lunatask_mcp.api.client_tasks import TasksClientMixin
 
 
@@ -19,6 +20,7 @@ class LunaTaskClient(
     NotesClientMixin,
     JournalClientMixin,
     HabitsClientMixin,
+    PeopleClientMixin,
 ):
     """Complete LunaTask API client with all functionality.
 

--- a/src/lunatask_mcp/api/client_people.py
+++ b/src/lunatask_mcp/api/client_people.py
@@ -1,0 +1,73 @@
+"""People functionality mixin for LunaTask API client.
+
+This module provides the PeopleClientMixin class that handles person creation
+operations, designed to be composed with the base client.
+"""
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from lunatask_mcp.api.exceptions import LunaTaskAPIError
+from lunatask_mcp.api.models_people import PersonCreate, PersonResponse
+
+if TYPE_CHECKING:
+    from lunatask_mcp.api.protocols import BaseClientProtocol
+
+logger = logging.getLogger(__name__)
+
+
+class PeopleClientMixin:
+    """Mixin providing person creation functionality for the LunaTask API client."""
+
+    async def create_person(
+        self: "BaseClientProtocol", person_data: PersonCreate
+    ) -> PersonResponse | None:
+        """Create a new person in the LunaTask API.
+
+        Args:
+            person_data: PersonCreate object containing person data to create.
+
+        Returns:
+            PersonResponse | None: Created person object from the API, or None when
+            the API returns 204 No Content due to duplicate source/source_id.
+
+        Raises:
+            LunaTaskValidationError: Validation error (422)
+            LunaTaskSubscriptionRequiredError: Subscription required (402)
+            LunaTaskAuthenticationError: Invalid bearer token (401)
+            LunaTaskRateLimitError: Rate limit exceeded (429)
+            LunaTaskServerError: Server error occurred (5xx)
+            LunaTaskServiceUnavailableError: Service unavailable (503)
+            LunaTaskTimeoutError: Request timeout
+            LunaTaskNetworkError: Network connectivity error
+            LunaTaskAPIError: Other API errors
+        """
+        json_data = json.loads(person_data.model_dump_json(exclude_none=True))
+
+        response_data = await self.make_request("POST", "people", data=json_data)
+
+        if not response_data:
+            logger.debug(
+                "Person creation returned no content; assuming duplicate for source/source_id"
+            )
+            return None
+
+        try:
+            person_payload = response_data["person"]
+            person = PersonResponse(**person_payload)
+        except KeyError as error:
+            logger.exception("Failed to extract person from wrapped response format")
+            person_name = f"{json_data.get('first_name', '')} {json_data.get('last_name', '')}"
+            raise LunaTaskAPIError.create_parse_error(
+                "people", person_name=f"{person_name.strip()} - missing 'person' key"
+            ) from error
+        except Exception as error:
+            logger.exception("Failed to parse created person response data")
+            person_name = f"{json_data.get('first_name', '')} {json_data.get('last_name', '')}"
+            raise LunaTaskAPIError.create_parse_error(
+                "people", person_name=person_name.strip()
+            ) from error
+        else:
+            logger.debug("Successfully created person: %s", person.id)
+            return person

--- a/src/lunatask_mcp/api/client_person_timeline_notes.py
+++ b/src/lunatask_mcp/api/client_person_timeline_notes.py
@@ -1,0 +1,69 @@
+"""Person timeline notes functionality mixin for the LunaTask API client.
+
+This module exposes a mixin providing the capability to create timeline notes
+associated with people in LunaTask.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from lunatask_mcp.api.exceptions import LunaTaskAPIError
+from lunatask_mcp.api.models_people import (
+    PersonTimelineNoteCreate,
+    PersonTimelineNoteResponse,
+)
+
+if TYPE_CHECKING:
+    from lunatask_mcp.api.protocols import BaseClientProtocol
+
+logger = logging.getLogger(__name__)
+
+
+class PersonTimelineNotesClientMixin:
+    """Mixin providing person timeline note creation functionality."""
+
+    async def create_person_timeline_note(
+        self: BaseClientProtocol, payload: PersonTimelineNoteCreate
+    ) -> PersonTimelineNoteResponse:
+        """Create a person timeline note through the LunaTask API.
+
+        Args:
+            payload: PersonTimelineNoteCreate object describing the note.
+
+        Returns:
+            PersonTimelineNoteResponse: Parsed response for the created note.
+
+        Raises:
+            LunaTaskValidationError: Validation error (422)
+            LunaTaskSubscriptionRequiredError: Subscription required (402)
+            LunaTaskAuthenticationError: Invalid bearer token (401)
+            LunaTaskRateLimitError: Rate limit exceeded (429)
+            LunaTaskServerError: Server error occurred (5xx)
+            LunaTaskServiceUnavailableError: Service unavailable (503)
+            LunaTaskTimeoutError: Request timeout
+            LunaTaskNetworkError: Network connectivity error
+            LunaTaskAPIError: Other API errors or parse failures
+        """
+
+        json_payload = json.loads(payload.model_dump_json(exclude_none=True))
+        response_data = await self.make_request("POST", "person_timeline_notes", data=json_payload)
+
+        try:
+            note_data = response_data["person_timeline_note"]
+            note = PersonTimelineNoteResponse(**note_data)
+        except KeyError as error:
+            logger.exception("Missing person_timeline_note wrapper in response payload")
+            raise LunaTaskAPIError.create_parse_error(
+                "person_timeline_notes", person_id=json_payload.get("person_id", "unknown")
+            ) from error
+        except Exception as error:
+            logger.exception("Failed to parse person timeline note response payload")
+            raise LunaTaskAPIError.create_parse_error(
+                "person_timeline_notes", person_id=json_payload.get("person_id", "unknown")
+            ) from error
+
+        logger.debug("Created person timeline note %s", note.id)
+        return note

--- a/src/lunatask_mcp/api/models_people.py
+++ b/src/lunatask_mcp/api/models_people.py
@@ -84,3 +84,48 @@ class PersonResponse(BaseSourceResponse):
     def __init__(self, **data: object) -> None:
         """Pydantic-compatible initializer with permissive typing for tools/tests."""
         super().__init__(**data)  # type: ignore[arg-type]
+
+
+class PersonTimelineNoteCreate(BaseModel):
+    """Request model for creating a person timeline note in LunaTask.
+
+    The LunaTask API requires a person identifier, with optional content and
+    date information. Fields set to ``None`` are excluded from the serialized
+    payload to keep requests minimal.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    person_id: str = Field(min_length=1, description="Identifier of the person the note belongs to")
+    content: str | None = Field(
+        default=None,
+        description="Markdown content of the timeline note",
+    )
+    date_on: date | None = Field(
+        default=None,
+        description="Optional ISO-8601 date string for when the note occurred",
+    )
+
+    def __init__(self, **data: object) -> None:
+        """Pydantic-compatible initializer with permissive typing for tools/tests."""
+        super().__init__(**data)  # type: ignore[arg-type]
+
+
+class PersonTimelineNoteResponse(BaseModel):
+    """Response model for person timeline note creation.
+
+    The LunaTask API wraps created notes inside ``{"person_timeline_note": {...}}``
+    payloads. This model captures the stable fields the client depends on while
+    ignoring any additional attributes sent by the API for forward compatibility.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(min_length=1, description="Unique identifier for the timeline note")
+    date_on: date = Field(description="Date associated with the timeline note")
+    created_at: datetime = Field(description="Timestamp when the note was created")
+    updated_at: datetime = Field(description="Timestamp when the note was last updated")
+
+    def __init__(self, **data: object) -> None:
+        """Pydantic-compatible initializer with permissive typing for tools/tests."""
+        super().__init__(**data)  # type: ignore[arg-type]

--- a/src/lunatask_mcp/api/models_people.py
+++ b/src/lunatask_mcp/api/models_people.py
@@ -1,0 +1,86 @@
+"""Data models for LunaTask People API requests and responses.
+
+This module defines Pydantic models and enums for people/contact management
+in LunaTask. Follows the same patterns as the main models module with
+StrEnum for relationship strength and BaseSourceResponse for consistency.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+from pydantic.config import ConfigDict
+
+from .models import BaseSourceResponse
+
+
+class PersonRelationshipStrength(StrEnum):
+    """Relationship strength values accepted by LunaTask person creation."""
+
+    FAMILY = "family"
+    INTIMATE_FRIENDS = "intimate-friends"
+    CLOSE_FRIENDS = "close-friends"
+    CASUAL_FRIENDS = "casual-friends"
+    ACQUAINTANCES = "acquaintances"
+    BUSINESS_CONTACTS = "business-contacts"
+    ALMOST_STRANGERS = "almost-strangers"
+
+
+class PersonCreate(BaseModel):
+    """Request model for creating new people in LunaTask.
+
+    Follows the LunaTask people API specification with required name fields
+    and optional relationship metadata and custom fields.
+    """
+
+    model_config = ConfigDict(use_enum_values=True, extra="forbid")
+
+    first_name: str = Field(description="Person's first name")
+    last_name: str = Field(description="Person's last name")
+    relationship_strength: PersonRelationshipStrength = Field(
+        default=PersonRelationshipStrength.CASUAL_FRIENDS,
+        description="Relationship strength level",
+    )
+    source: str | None = Field(
+        default=None,
+        description="Identifier of external system where the person originated",
+    )
+    source_id: str | None = Field(
+        default=None,
+        description="Identifier of the person record in the external system",
+    )
+    email: str | None = Field(default=None, description="Person's email address")
+    birthday: date | None = Field(default=None, description="Person's birthday (ISO-8601 date)")
+    phone: str | None = Field(default=None, description="Person's phone number")
+
+    def __init__(self, **data: object) -> None:
+        """Pydantic-compatible initializer with permissive typing for tools/tests."""
+        super().__init__(**data)  # type: ignore[arg-type]
+
+
+class PersonResponse(BaseSourceResponse):
+    """Response model for LunaTask person data.
+
+    The LunaTask API returns created people wrapped inside `{"person": {...}}`.
+    Inherits source normalization logic from BaseSourceResponse.
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    id: str = Field(min_length=1, description="Unique identifier of the person (UUID)")
+    relationship_strength: PersonRelationshipStrength = Field(
+        description="Relationship strength level"
+    )
+    created_at: datetime = Field(description="Timestamp when the person was created")
+    updated_at: datetime = Field(description="Timestamp when the person was last updated")
+
+    # Optional persisted custom fields that may be returned
+    email: str | None = Field(default=None, description="Person's email address")
+    birthday: date | None = Field(default=None, description="Person's birthday")
+    phone: str | None = Field(default=None, description="Person's phone number")
+
+    def __init__(self, **data: object) -> None:
+        """Pydantic-compatible initializer with permissive typing for tools/tests."""
+        super().__init__(**data)  # type: ignore[arg-type]

--- a/src/lunatask_mcp/main.py
+++ b/src/lunatask_mcp/main.py
@@ -33,6 +33,7 @@ from lunatask_mcp.config import ServerConfig
 from lunatask_mcp.tools.habits import HabitTools
 from lunatask_mcp.tools.journal import JournalTools
 from lunatask_mcp.tools.notes import NotesTools
+from lunatask_mcp.tools.people import PeopleTools
 from lunatask_mcp.tools.tasks import TaskTools
 
 
@@ -97,6 +98,7 @@ class CoreServer:
         HabitTools(self.app, lunatask_client)
         NotesTools(self.app, lunatask_client)
         JournalTools(self.app, lunatask_client)
+        PeopleTools(self.app, lunatask_client)
 
     def _setup_signal_handlers(self) -> None:
         """Set up signal handlers for graceful shutdown.

--- a/src/lunatask_mcp/tools/people.py
+++ b/src/lunatask_mcp/tools/people.py
@@ -1,0 +1,247 @@
+"""People/contact management tools for LunaTask MCP integration."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date as date_class
+from typing import Any
+
+from fastmcp import FastMCP
+from fastmcp.server.context import Context as ServerContext
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import (
+    LunaTaskAPIError,
+    LunaTaskAuthenticationError,
+    LunaTaskNetworkError,
+    LunaTaskRateLimitError,
+    LunaTaskServerError,
+    LunaTaskServiceUnavailableError,
+    LunaTaskSubscriptionRequiredError,
+    LunaTaskTimeoutError,
+    LunaTaskValidationError,
+)
+from lunatask_mcp.api.models_people import PersonCreate, PersonRelationshipStrength
+
+logger = logging.getLogger(__name__)
+
+
+class PeopleTools:
+    """People/contact management tools providing MCP integrations for LunaTask people."""
+
+    def __init__(self, mcp_instance: FastMCP, lunatask_client: LunaTaskClient) -> None:
+        """Initialize PeopleTools with FastMCP instance and LunaTask client."""
+
+        self.mcp = mcp_instance
+        self.lunatask_client = lunatask_client
+        self._register_tools()
+
+    async def create_person_tool(  # noqa: PLR0913, PLR0911, PLR0912, PLR0915, C901
+        self,
+        ctx: ServerContext,
+        first_name: str,
+        last_name: str,
+        relationship_strength: str | None = None,
+        source: str | None = None,
+        source_id: str | None = None,
+        email: str | None = None,
+        birthday: str | None = None,
+        phone: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a person in LunaTask with optional duplicate detection."""
+
+        await ctx.info("Creating new person")
+
+        # Validate and convert relationship_strength
+        parsed_relationship_strength = PersonRelationshipStrength.CASUAL_FRIENDS
+        if relationship_strength is not None:
+            try:
+                parsed_relationship_strength = PersonRelationshipStrength(relationship_strength)
+            except ValueError:
+                valid_values = ", ".join([e.value for e in PersonRelationshipStrength])
+                message = (
+                    f"Invalid relationship_strength '{relationship_strength}'. "
+                    f"Must be one of: {valid_values}"
+                )
+                await ctx.error(message)
+                logger.warning("Invalid relationship_strength provided: %s", relationship_strength)
+                return {
+                    "success": False,
+                    "error": "validation_error",
+                    "message": message,
+                }
+
+        # Parse birthday if provided
+        parsed_birthday: date_class | None = None
+        if birthday is not None:
+            try:
+                parsed_birthday = date_class.fromisoformat(birthday)
+            except ValueError as error:
+                message = f"Invalid birthday format. Expected YYYY-MM-DD format: {error!s}"
+                await ctx.error(message)
+                logger.warning("Invalid birthday provided for create_person: %s", birthday)
+                return {
+                    "success": False,
+                    "error": "validation_error",
+                    "message": message,
+                }
+
+        person_payload = PersonCreate(
+            first_name=first_name,
+            last_name=last_name,
+            relationship_strength=parsed_relationship_strength,
+            source=source,
+            source_id=source_id,
+            email=email,
+            birthday=parsed_birthday,
+            phone=phone,
+        )
+
+        try:
+            async with self.lunatask_client as client:
+                person_response = await client.create_person(person_payload)
+
+        except LunaTaskValidationError as error:
+            message = f"Person validation failed: {error}"
+            await ctx.error(message)
+            logger.warning("Person validation error: %s", error)
+            return {
+                "success": False,
+                "error": "validation_error",
+                "message": message,
+            }
+
+        except LunaTaskSubscriptionRequiredError as error:
+            message = f"Subscription required: {error}"
+            await ctx.error(message)
+            logger.warning("Subscription required during person creation: %s", error)
+            return {
+                "success": False,
+                "error": "subscription_required",
+                "message": message,
+            }
+
+        except LunaTaskAuthenticationError as error:
+            message = f"Authentication failed: {error}"
+            await ctx.error(message)
+            logger.warning("Authentication error during person creation: %s", error)
+            return {
+                "success": False,
+                "error": "authentication_error",
+                "message": message,
+            }
+
+        except LunaTaskRateLimitError as error:
+            message = f"Rate limit exceeded: {error}"
+            await ctx.error(message)
+            logger.warning("Rate limit exceeded during person creation: %s", error)
+            return {
+                "success": False,
+                "error": "rate_limit_error",
+                "message": message,
+            }
+
+        except (LunaTaskServerError, LunaTaskServiceUnavailableError) as error:
+            message = f"Server error: {error}"
+            await ctx.error(message)
+            logger.warning("Server error during person creation: %s", error)
+            return {
+                "success": False,
+                "error": "server_error",
+                "message": message,
+            }
+
+        except LunaTaskTimeoutError as error:
+            message = f"Request timeout: {error}"
+            await ctx.error(message)
+            logger.warning("Timeout during person creation: %s", error)
+            return {
+                "success": False,
+                "error": "timeout_error",
+                "message": message,
+            }
+
+        except LunaTaskNetworkError as error:
+            message = f"Network error: {error}"
+            await ctx.error(message)
+            logger.warning("Network error during person creation: %s", error)
+            return {
+                "success": False,
+                "error": "network_error",
+                "message": message,
+            }
+
+        except LunaTaskAPIError as error:
+            message = f"API error: {error}"
+            await ctx.error(message)
+            logger.warning("API error during person creation: %s", error)
+            return {
+                "success": False,
+                "error": "api_error",
+                "message": message,
+            }
+
+        except Exception as error:
+            message = f"Unexpected error creating person: {error}"
+            await ctx.error(message)
+            logger.exception("Unexpected error during person creation")
+            return {
+                "success": False,
+                "error": "unexpected_error",
+                "message": message,
+            }
+
+        if person_response is None:
+            duplicate_message = "Person already exists for this source/source_id"
+            await ctx.info("Person already exists; duplicate create skipped")
+            logger.info("Duplicate person detected for source=%s, source_id=%s", source, source_id)
+            return {
+                "success": True,
+                "duplicate": True,
+                "message": duplicate_message,
+            }
+
+        await ctx.info(f"Successfully created person {person_response.id}")
+        logger.info("Successfully created person %s", person_response.id)
+        return {
+            "success": True,
+            "person_id": person_response.id,
+            "message": "Person created successfully",
+        }
+
+    def _register_tools(self) -> None:
+        """Register people-related MCP tools with the FastMCP instance."""
+
+        async def _create_person(  # noqa: PLR0913
+            ctx: ServerContext,
+            first_name: str,
+            last_name: str,
+            relationship_strength: str | None = None,
+            source: str | None = None,
+            source_id: str | None = None,
+            email: str | None = None,
+            birthday: str | None = None,
+            phone: str | None = None,
+        ) -> dict[str, Any]:
+            return await self.create_person_tool(
+                ctx,
+                first_name,
+                last_name,
+                relationship_strength,
+                source,
+                source_id,
+                email,
+                birthday,
+                phone,
+            )
+
+        valid_strengths = ", ".join([e.value for e in PersonRelationshipStrength])
+        self.mcp.tool(
+            name="create_person",
+            description=(
+                f"Create a person/contact in LunaTask. Requires first_name and last_name. "
+                f"Optional relationship_strength ({valid_strengths}), "
+                f"source/source_id for duplicate detection, email, birthday (YYYY-MM-DD), "
+                f"and phone. Returns person_id or duplicate status."
+            ),
+        )(_create_person)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -14,6 +14,13 @@ from pydantic_core import InitErrorDetails, PydanticCustomError
 
 from lunatask_mcp.api.models import JournalEntryResponse, NoteResponse, TaskResponse
 
+# People models will be available after Phase 2 implementation
+try:
+    from lunatask_mcp.api.models_people import PersonResponse
+except ImportError:
+    # Placeholder for TDD phase - will be replaced with actual import
+    PersonResponse = None  # type: ignore[misc,assignment]
+
 VALID_ESTIMATE_MINUTES = 45
 VALID_PROGRESS_PERCENT = 80
 VALID_GOAL_ID = "goal-123"
@@ -175,6 +182,77 @@ def create_journal_entry_response(  # noqa: PLR0913
         payload["content"] = content
 
     return JournalEntryResponse(**payload)
+
+
+def create_person_response(  # noqa: PLR0913
+    person_id: str = "5999b945-b2b1-48c6-aa72-b251b75b3c2e",
+    relationship_strength: str = "casual-friends",
+    source: str | None = None,
+    source_id: str | None = None,
+    created_at: datetime | None = None,
+    updated_at: datetime | None = None,
+    email: str | None = None,
+    birthday: date | None = None,
+    phone: str | None = None,
+) -> object:
+    """Create a PersonResponse object with default or provided values.
+
+    Args:
+        person_id: Person ID (default: "5999b945-b2b1-48c6-aa72-b251b75b3c2e")
+        relationship_strength: Relationship strength (default: "casual-friends")
+        source: Source system identifier (default: None)
+        source_id: Source system record ID (default: None)
+        created_at: Creation timestamp (default: 2021-01-10 10:39:25 UTC)
+        updated_at: Last update timestamp (default: 2021-01-10 10:39:25 UTC)
+        email: Person's email address (default: None)
+        birthday: Person's birthday (default: None)
+        phone: Person's phone number (default: None)
+
+    Returns:
+        PersonResponse object suitable for mocking API responses.
+    """
+    if created_at is None:
+        created_at = datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC)
+    if updated_at is None:
+        updated_at = datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC)
+
+    # Handle sources similar to other response factories
+    if source is not None or source_id is not None:
+        sources_payload = [{"source": source, "source_id": source_id}]
+    else:
+        sources_payload = []
+
+    # During TDD phase, return a mock object that behaves like PersonResponse
+    if PersonResponse is None:
+        # Return a simple object with the expected attributes for testing
+        class MockPersonResponse:
+            def __init__(self, **kwargs: object) -> None:
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+
+        return MockPersonResponse(
+            id=person_id,
+            relationship_strength=relationship_strength,
+            sources=sources_payload,
+            created_at=created_at,
+            updated_at=updated_at,
+            email=email,
+            birthday=birthday,
+            phone=phone,
+        )
+
+    # Once PersonResponse is implemented, use the real model
+    return PersonResponse(
+        id=person_id,
+        relationship_strength=relationship_strength,
+        source=source,
+        source_id=source_id,
+        created_at=created_at,
+        updated_at=updated_at,
+        email=email,
+        birthday=birthday,
+        phone=phone,
+    )
 
 
 def build_validation_error(

--- a/tests/test_api_client_create_person.py
+++ b/tests/test_api_client_create_person.py
@@ -1,0 +1,366 @@
+"""Tests for LunaTaskClient.create_person()."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import (
+    LunaTaskAPIError,
+    LunaTaskAuthenticationError,
+    LunaTaskNetworkError,
+    LunaTaskRateLimitError,
+    LunaTaskServerError,
+    LunaTaskServiceUnavailableError,
+    LunaTaskSubscriptionRequiredError,
+    LunaTaskTimeoutError,
+    LunaTaskValidationError,
+)
+from lunatask_mcp.api.models_people import PersonCreate, PersonRelationshipStrength, PersonResponse
+from lunatask_mcp.config import ServerConfig
+from tests.test_api_client_common import DEFAULT_API_URL, VALID_TOKEN
+
+
+class TestLunaTaskClientCreatePerson:
+    """Test suite for LunaTaskClient.create_person()."""
+
+    @pytest.mark.asyncio
+    async def test_create_person_success_all_fields(self, mocker: MockerFixture) -> None:
+        """Client should deserialize wrapped person response on success."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+
+        person_payload = PersonCreate(
+            first_name="John",
+            last_name="Doe",
+            relationship_strength=PersonRelationshipStrength.BUSINESS_CONTACTS,
+            source="salesforce",
+            source_id="352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7",
+            email="john.doe@example.com",
+            birthday=date(1985, 3, 20),
+            phone="+1-555-123-4567",
+        )
+
+        mock_response: dict[str, Any] = {
+            "person": {
+                "id": "5999b945-b2b1-48c6-aa72-b251b75b3c2e",
+                "relationship_strength": "business-contacts",
+                "sources": [
+                    {"source": "salesforce", "source_id": "352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7"},
+                ],
+                "created_at": "2021-01-10T10:39:25Z",
+                "updated_at": "2021-01-10T10:39:25Z",
+            }
+        }
+
+        mock_make_request = mocker.patch.object(client, "make_request", return_value=mock_response)
+
+        result = await client.create_person(person_payload)
+
+        assert isinstance(result, PersonResponse)
+        assert result.id == "5999b945-b2b1-48c6-aa72-b251b75b3c2e"
+        assert result.relationship_strength == PersonRelationshipStrength.BUSINESS_CONTACTS
+        assert result.source == "salesforce"
+        assert result.source_id == "352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7"
+        assert result.created_at == datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC)
+        assert result.updated_at == datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC)
+
+        mock_make_request.assert_called_once_with(
+            "POST",
+            "people",
+            data={
+                "first_name": "John",
+                "last_name": "Doe",
+                "relationship_strength": "business-contacts",
+                "source": "salesforce",
+                "source_id": "352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7",
+                "email": "john.doe@example.com",
+                "birthday": "1985-03-20",
+                "phone": "+1-555-123-4567",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_person_success_minimal_fields(self, mocker: MockerFixture) -> None:
+        """Client should handle minimal person creation with only required fields."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+
+        person_payload = PersonCreate(first_name="Jane", last_name="Smith")
+
+        mock_response: dict[str, Any] = {
+            "person": {
+                "id": "8888c945-b2b1-48c6-aa72-b251b75b3c2e",
+                "relationship_strength": "casual-friends",
+                "sources": [],
+                "created_at": "2021-01-10T10:39:25Z",
+                "updated_at": "2021-01-10T10:39:25Z",
+            }
+        }
+
+        mock_make_request = mocker.patch.object(client, "make_request", return_value=mock_response)
+
+        result = await client.create_person(person_payload)
+
+        assert isinstance(result, PersonResponse)
+        assert result.id == "8888c945-b2b1-48c6-aa72-b251b75b3c2e"
+        assert result.relationship_strength == PersonRelationshipStrength.CASUAL_FRIENDS
+
+        mock_make_request.assert_called_once_with(
+            "POST",
+            "people",
+            data={
+                "first_name": "Jane",
+                "last_name": "Smith",
+                "relationship_strength": "casual-friends",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_person_duplicate_returns_none(self, mocker: MockerFixture) -> None:
+        """204 No Content response should return None to signal duplicate detected."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        person_payload = PersonCreate(first_name="John", last_name="Doe")
+
+        mock_make_request = mocker.patch.object(client, "make_request", return_value={})
+
+        result = await client.create_person(person_payload)
+
+        assert result is None
+        mock_make_request.assert_called_once_with(
+            "POST",
+            "people",
+            data={
+                "first_name": "John",
+                "last_name": "Doe",
+                "relationship_strength": "casual-friends",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_person_authentication_error(self, mocker: MockerFixture) -> None:
+        """Propagate authentication errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        person_payload = PersonCreate(first_name="John", last_name="Doe")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskAuthenticationError("Invalid bearer token"),
+        )
+
+        with pytest.raises(LunaTaskAuthenticationError, match="Invalid bearer token"):
+            await client.create_person(person_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_subscription_required_error(self, mocker: MockerFixture) -> None:
+        """Propagate subscription required errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        person_payload = PersonCreate(first_name="John", last_name="Doe")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskSubscriptionRequiredError("Subscription upgrade required"),
+        )
+
+        with pytest.raises(
+            LunaTaskSubscriptionRequiredError, match="Subscription upgrade required"
+        ):
+            await client.create_person(person_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_validation_error(self, mocker: MockerFixture) -> None:
+        """Propagate validation errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        person_payload = PersonCreate(first_name="John", last_name="Doe")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskValidationError("Custom fields for email not defined in app"),
+        )
+
+        with pytest.raises(
+            LunaTaskValidationError, match="Custom fields for email not defined in app"
+        ):
+            await client.create_person(person_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_rate_limit_error(self, mocker: MockerFixture) -> None:
+        """Propagate rate limit errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        person_payload = PersonCreate(first_name="John", last_name="Doe")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskRateLimitError("Rate limit exceeded"),
+        )
+
+        with pytest.raises(LunaTaskRateLimitError, match="Rate limit exceeded"):
+            await client.create_person(person_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_server_error(self, mocker: MockerFixture) -> None:
+        """Propagate server errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        person_payload = PersonCreate(first_name="John", last_name="Doe")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskServerError("Internal server error", status_code=500),
+        )
+
+        with pytest.raises(LunaTaskServerError, match="Internal server error"):
+            await client.create_person(person_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_service_unavailable_error(self, mocker: MockerFixture) -> None:
+        """Propagate service unavailable errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        person_payload = PersonCreate(first_name="John", last_name="Doe")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskServiceUnavailableError("Service temporarily unavailable"),
+        )
+
+        with pytest.raises(
+            LunaTaskServiceUnavailableError, match="Service temporarily unavailable"
+        ):
+            await client.create_person(person_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeout_error(self, mocker: MockerFixture) -> None:
+        """Propagate timeout errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        person_payload = PersonCreate(first_name="John", last_name="Doe")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskTimeoutError("Request timeout"),
+        )
+
+        with pytest.raises(LunaTaskTimeoutError, match="Request timeout"):
+            await client.create_person(person_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_network_error(self, mocker: MockerFixture) -> None:
+        """Propagate network errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        person_payload = PersonCreate(first_name="John", last_name="Doe")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskNetworkError("Network connection failed"),
+        )
+
+        with pytest.raises(LunaTaskNetworkError, match="Network connection failed"):
+            await client.create_person(person_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_parse_error_missing_person_key(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Missing wrapped person should raise a LunaTaskAPIError parse error."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        person_payload = PersonCreate(first_name="John", last_name="Doe")
+
+        mocker.patch.object(client, "make_request", return_value={"unexpected": {}})
+
+        with pytest.raises(LunaTaskAPIError, match="Failed to parse response"):
+            await client.create_person(person_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_parse_error_malformed_data(self, mocker: MockerFixture) -> None:
+        """Malformed person data should raise a LunaTaskAPIError parse error."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        person_payload = PersonCreate(first_name="John", last_name="Doe")
+
+        # Missing required fields in response
+        mock_response: dict[str, Any] = {
+            "person": {
+                "id": "5999b945-b2b1-48c6-aa72-b251b75b3c2e",
+                # Missing relationship_strength, created_at, updated_at
+            }
+        }
+
+        mocker.patch.object(client, "make_request", return_value=mock_response)
+
+        with pytest.raises(LunaTaskAPIError, match="Failed to parse response"):
+            await client.create_person(person_payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_serializes_with_exclude_none(self, mocker: MockerFixture) -> None:
+        """PersonCreate should be serialized with exclude_none=True behavior."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+
+        person_payload = PersonCreate(
+            first_name="John",
+            last_name="Doe",
+            source="github",
+            # source_id, email, birthday, phone are None and should be excluded
+        )
+
+        mock_response: dict[str, Any] = {
+            "person": {
+                "id": "5999b945-b2b1-48c6-aa72-b251b75b3c2e",
+                "relationship_strength": "casual-friends",
+                "sources": [{"source": "github", "source_id": None}],
+                "created_at": "2021-01-10T10:39:25Z",
+                "updated_at": "2021-01-10T10:39:25Z",
+            }
+        }
+
+        mock_make_request = mocker.patch.object(client, "make_request", return_value=mock_response)
+
+        await client.create_person(person_payload)
+
+        # Verify that None values were excluded from the serialized data
+        call_args = mock_make_request.call_args
+        sent_data = call_args[1]["data"]
+
+        assert "first_name" in sent_data
+        assert "last_name" in sent_data
+        assert "relationship_strength" in sent_data
+        assert "source" in sent_data
+        # These None fields should not be present
+        assert "source_id" not in sent_data
+        assert "email" not in sent_data
+        assert "birthday" not in sent_data
+        assert "phone" not in sent_data

--- a/tests/test_api_client_create_person_timeline_note.py
+++ b/tests/test_api_client_create_person_timeline_note.py
@@ -1,0 +1,235 @@
+"""Tests for LunaTaskClient.create_person_timeline_note()."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import (
+    LunaTaskAPIError,
+    LunaTaskAuthenticationError,
+    LunaTaskNetworkError,
+    LunaTaskRateLimitError,
+    LunaTaskServerError,
+    LunaTaskServiceUnavailableError,
+    LunaTaskSubscriptionRequiredError,
+    LunaTaskTimeoutError,
+    LunaTaskValidationError,
+)
+from lunatask_mcp.api.models_people import (
+    PersonTimelineNoteCreate,
+    PersonTimelineNoteResponse,
+)
+from lunatask_mcp.config import ServerConfig
+from tests.test_api_client_common import DEFAULT_API_URL, VALID_TOKEN
+
+
+class TestLunaTaskClientCreatePersonTimelineNote:
+    """Test suite for LunaTaskClient.create_person_timeline_note()."""
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_success(self, mocker: MockerFixture) -> None:
+        """Client should unwrap and parse the person timeline note response."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+
+        payload = PersonTimelineNoteCreate(
+            person_id="person-123",
+            content="Called mom to check in",
+            date_on=date(2025, 9, 20),
+        )
+
+        mock_response: dict[str, Any] = {
+            "person_timeline_note": {
+                "id": "timeline-note-123",
+                "date_on": "2025-09-20",
+                "created_at": "2025-09-20T12:15:00Z",
+                "updated_at": "2025-09-20T12:15:00Z",
+            }
+        }
+
+        mock_make_request = mocker.patch.object(client, "make_request", return_value=mock_response)
+
+        result = await client.create_person_timeline_note(payload)
+
+        assert isinstance(result, PersonTimelineNoteResponse)
+        assert result.id == "timeline-note-123"
+        assert result.date_on == date(2025, 9, 20)
+        assert result.created_at == datetime(2025, 9, 20, 12, 15, tzinfo=UTC)
+        assert result.updated_at == datetime(2025, 9, 20, 12, 15, tzinfo=UTC)
+
+        mock_make_request.assert_called_once_with(
+            "POST",
+            "person_timeline_notes",
+            data={
+                "person_id": "person-123",
+                "content": "Called mom to check in",
+                "date_on": "2025-09-20",
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_parse_error_missing_wrapper(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Missing wrapper key should raise a LunaTaskAPIError parse error."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        payload = PersonTimelineNoteCreate(person_id="person-123", content="Note")
+
+        mocker.patch.object(client, "make_request", return_value={"unexpected": {}})
+
+        with pytest.raises(LunaTaskAPIError, match="Failed to parse response"):
+            await client.create_person_timeline_note(payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_validation_error(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Propagate validation errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        payload = PersonTimelineNoteCreate(person_id="person-123", content="Note")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskValidationError("Invalid payload"),
+        )
+
+        with pytest.raises(LunaTaskValidationError, match="Invalid payload"):
+            await client.create_person_timeline_note(payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_subscription_required_error(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Propagate subscription required errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        payload = PersonTimelineNoteCreate(person_id="person-123", content="Note")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskSubscriptionRequiredError("Upgrade required"),
+        )
+
+        with pytest.raises(LunaTaskSubscriptionRequiredError, match="Upgrade required"):
+            await client.create_person_timeline_note(payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_authentication_error(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Propagate authentication errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        payload = PersonTimelineNoteCreate(person_id="person-123", content="Note")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskAuthenticationError("Invalid token"),
+        )
+
+        with pytest.raises(LunaTaskAuthenticationError, match="Invalid token"):
+            await client.create_person_timeline_note(payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_rate_limit_error(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Propagate rate limit errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        payload = PersonTimelineNoteCreate(person_id="person-123", content="Note")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskRateLimitError("Rate limit exceeded"),
+        )
+
+        with pytest.raises(LunaTaskRateLimitError, match="Rate limit exceeded"):
+            await client.create_person_timeline_note(payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_timeout_error(self, mocker: MockerFixture) -> None:
+        """Propagate timeout errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        payload = PersonTimelineNoteCreate(person_id="person-123", content="Note")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskTimeoutError("Request timed out"),
+        )
+
+        with pytest.raises(LunaTaskTimeoutError, match="Request timed out"):
+            await client.create_person_timeline_note(payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_network_error(self, mocker: MockerFixture) -> None:
+        """Propagate network errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        payload = PersonTimelineNoteCreate(person_id="person-123", content="Note")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskNetworkError("Network issue"),
+        )
+
+        with pytest.raises(LunaTaskNetworkError, match="Network issue"):
+            await client.create_person_timeline_note(payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_server_error(self, mocker: MockerFixture) -> None:
+        """Propagate server errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        payload = PersonTimelineNoteCreate(person_id="person-123", content="Note")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskServerError("Internal error", status_code=500),
+        )
+
+        with pytest.raises(LunaTaskServerError, match="Internal error"):
+            await client.create_person_timeline_note(payload)
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_service_unavailable_error(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Propagate service unavailable errors from make_request."""
+
+        config = ServerConfig(lunatask_bearer_token=VALID_TOKEN, lunatask_base_url=DEFAULT_API_URL)
+        client = LunaTaskClient(config)
+        payload = PersonTimelineNoteCreate(person_id="person-123", content="Note")
+
+        mocker.patch.object(
+            client,
+            "make_request",
+            side_effect=LunaTaskServiceUnavailableError("Service unavailable"),
+        )
+
+        with pytest.raises(LunaTaskServiceUnavailableError, match="Service unavailable"):
+            await client.create_person_timeline_note(payload)

--- a/tests/test_api_models_people.py
+++ b/tests/test_api_models_people.py
@@ -1,0 +1,247 @@
+"""Tests for LunaTask people models."""
+
+import json
+from datetime import UTC, date, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from lunatask_mcp.api.models_people import (
+    PersonCreate,
+    PersonRelationshipStrength,
+    PersonResponse,
+)
+
+
+class TestPersonRelationshipStrength:
+    """Test suite for PersonRelationshipStrength enum."""
+
+    def test_enum_has_all_required_values(self) -> None:
+        """PersonRelationshipStrength should have all 7 required relationship values."""
+        expected_values = {
+            "family",
+            "intimate-friends",
+            "close-friends",
+            "casual-friends",
+            "acquaintances",
+            "business-contacts",
+            "almost-strangers",
+        }
+        actual_values = {member.value for member in PersonRelationshipStrength}
+        assert actual_values == expected_values
+
+    def test_enum_validation_accepts_valid_values(self) -> None:
+        """PersonRelationshipStrength should validate all defined values."""
+        for strength in PersonRelationshipStrength:
+            # Should not raise ValidationError
+            assert PersonRelationshipStrength(strength.value) == strength
+
+    def test_enum_validation_rejects_invalid_values(self) -> None:
+        """PersonRelationshipStrength should reject invalid relationship values."""
+        with pytest.raises(ValueError, match="invalid-strength"):
+            PersonRelationshipStrength("invalid-strength")
+
+
+class TestPersonCreate:
+    """Test suite for PersonCreate model."""
+
+    def test_create_with_minimal_required_fields(self) -> None:
+        """PersonCreate should work with only first_name and last_name."""
+        person = PersonCreate(first_name="John", last_name="Doe")
+
+        assert person.first_name == "John"
+        assert person.last_name == "Doe"
+        assert person.relationship_strength == PersonRelationshipStrength.CASUAL_FRIENDS
+        assert person.source is None
+        assert person.source_id is None
+        assert person.email is None
+        assert person.birthday is None
+        assert person.phone is None
+
+    def test_create_with_all_optional_fields(self) -> None:
+        """PersonCreate should accept all optional fields."""
+        person = PersonCreate(
+            first_name="Jane",
+            last_name="Smith",
+            relationship_strength=PersonRelationshipStrength.FAMILY,
+            source="salesforce",
+            source_id="352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7",
+            email="jane.smith@example.com",
+            birthday=date(1990, 5, 15),
+            phone="+1-555-123-4567",
+        )
+
+        assert person.first_name == "Jane"
+        assert person.last_name == "Smith"
+        assert person.relationship_strength == PersonRelationshipStrength.FAMILY
+        assert person.source == "salesforce"
+        assert person.source_id == "352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7"
+        assert person.email == "jane.smith@example.com"
+        assert person.birthday == date(1990, 5, 15)
+        assert person.phone == "+1-555-123-4567"
+
+    def test_serialization_excludes_none_values(self) -> None:
+        """PersonCreate serialization should exclude None values."""
+        person = PersonCreate(first_name="John", last_name="Doe", source="github")
+
+        payload = json.loads(person.model_dump_json(exclude_none=True))
+
+        assert payload["first_name"] == "John"
+        assert payload["last_name"] == "Doe"
+        assert payload["relationship_strength"] == "casual-friends"
+        assert payload["source"] == "github"
+        # None values should be excluded
+        assert "source_id" not in payload
+        assert "email" not in payload
+        assert "birthday" not in payload
+        assert "phone" not in payload
+
+    def test_birthday_serializes_to_iso_date_string(self) -> None:
+        """PersonCreate should serialize birthday as ISO-8601 date string."""
+        person = PersonCreate(first_name="Jane", last_name="Smith", birthday=date(1990, 12, 25))
+
+        payload = json.loads(person.model_dump_json(exclude_none=True))
+        assert payload["birthday"] == "1990-12-25"
+
+    def test_validation_error_missing_first_name(self) -> None:
+        """PersonCreate should raise ValidationError when first_name is missing."""
+        with pytest.raises(ValidationError) as exc_info:
+            PersonCreate(last_name="Doe")  # type: ignore[call-arg]
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("first_name",) for error in errors)
+
+    def test_validation_error_missing_last_name(self) -> None:
+        """PersonCreate should raise ValidationError when last_name is missing."""
+        with pytest.raises(ValidationError) as exc_info:
+            PersonCreate(first_name="John")  # type: ignore[call-arg]
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("last_name",) for error in errors)
+
+    def test_extra_fields_rejected(self) -> None:
+        """PersonCreate should reject extra fields not in the schema."""
+        with pytest.raises(ValidationError) as exc_info:
+            PersonCreate(
+                first_name="John",
+                last_name="Doe",
+                extra_field="not_allowed",  # type: ignore[call-arg]
+            )
+
+        errors = exc_info.value.errors()
+        assert any("extra_forbidden" in str(error) for error in errors)
+
+    def test_relationship_strength_default_value(self) -> None:
+        """PersonCreate should default relationship_strength to casual-friends."""
+        person = PersonCreate(first_name="John", last_name="Doe")
+        assert person.relationship_strength == PersonRelationshipStrength.CASUAL_FRIENDS
+
+    def test_relationship_strength_accepts_string_values(self) -> None:
+        """PersonCreate should accept string values for relationship_strength."""
+        person = PersonCreate(
+            first_name="John",
+            last_name="Doe",
+            relationship_strength="family",  # type: ignore[arg-type]
+        )
+        assert person.relationship_strength == PersonRelationshipStrength.FAMILY
+
+
+class TestPersonResponse:
+    """Test suite for PersonResponse model."""
+
+    def test_create_with_required_fields(self) -> None:
+        """PersonResponse should work with all required fields."""
+        person = PersonResponse(
+            id="5999b945-b2b1-48c6-aa72-b251b75b3c2e",
+            relationship_strength=PersonRelationshipStrength.BUSINESS_CONTACTS,
+            created_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+            updated_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+        )
+
+        assert person.id == "5999b945-b2b1-48c6-aa72-b251b75b3c2e"
+        assert person.relationship_strength == PersonRelationshipStrength.BUSINESS_CONTACTS
+        assert person.created_at == datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC)
+        assert person.updated_at == datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC)
+
+    def test_create_with_optional_persisted_fields(self) -> None:
+        """PersonResponse should include optional persisted fields when returned."""
+        person = PersonResponse(
+            id="5999b945-b2b1-48c6-aa72-b251b75b3c2e",
+            relationship_strength=PersonRelationshipStrength.FAMILY,
+            email="john.doe@example.com",
+            birthday=date(1985, 3, 20),
+            phone="+1-555-987-6543",
+            created_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+            updated_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+        )
+
+        assert person.email == "john.doe@example.com"
+        assert person.birthday == date(1985, 3, 20)
+        assert person.phone == "+1-555-987-6543"
+
+    def test_source_normalization_from_legacy_fields(self) -> None:
+        """PersonResponse should normalize legacy source fields into sources list."""
+        person = PersonResponse(
+            id="5999b945-b2b1-48c6-aa72-b251b75b3c2e",
+            relationship_strength=PersonRelationshipStrength.BUSINESS_CONTACTS,
+            source="salesforce",
+            source_id="352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7",
+            created_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+            updated_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+        )
+
+        assert len(person.sources) == 1
+        source_entry = person.sources[0]
+        assert source_entry.source == "salesforce"
+        assert source_entry.source_id == "352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7"
+
+    def test_computed_source_properties(self) -> None:
+        """PersonResponse should provide computed source properties for backwards compatibility."""
+        person = PersonResponse(
+            id="5999b945-b2b1-48c6-aa72-b251b75b3c2e",
+            relationship_strength=PersonRelationshipStrength.BUSINESS_CONTACTS,
+            sources=[{"source": "salesforce", "source_id": "352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7"}],
+            created_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+            updated_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+        )
+
+        assert person.source == "salesforce"
+        assert person.source_id == "352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7"
+
+    def test_computed_source_properties_return_none_when_no_sources(self) -> None:
+        """PersonResponse computed source properties should return None when no sources."""
+        person = PersonResponse(
+            id="5999b945-b2b1-48c6-aa72-b251b75b3c2e",
+            relationship_strength=PersonRelationshipStrength.CASUAL_FRIENDS,
+            created_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+            updated_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+        )
+
+        assert person.sources == []
+        assert person.source is None
+        assert person.source_id is None
+
+    def test_enum_serialization_uses_string_values(self) -> None:
+        """PersonResponse should serialize enum values as strings in JSON."""
+        person = PersonResponse(
+            id="5999b945-b2b1-48c6-aa72-b251b75b3c2e",
+            relationship_strength=PersonRelationshipStrength.INTIMATE_FRIENDS,
+            created_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+            updated_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+        )
+
+        payload = json.loads(person.model_dump_json())
+        assert payload["relationship_strength"] == "intimate-friends"
+
+    def test_field_validation_rejects_invalid_id(self) -> None:
+        """PersonResponse should validate field constraints."""
+        with pytest.raises(ValidationError) as exc_info:
+            PersonResponse(
+                id="",  # Empty string should fail
+                relationship_strength=PersonRelationshipStrength.FAMILY,
+                created_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+                updated_at=datetime(2021, 1, 10, 10, 39, 25, tzinfo=UTC),
+            )
+
+        errors = exc_info.value.errors()
+        assert any(error["loc"] == ("id",) for error in errors)

--- a/tests/test_api_models_person_timeline_notes.py
+++ b/tests/test_api_models_person_timeline_notes.py
@@ -1,0 +1,80 @@
+"""Tests for person timeline note Pydantic models."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from lunatask_mcp.api.models_people import (
+    PersonTimelineNoteCreate,
+    PersonTimelineNoteResponse,
+)
+
+
+def test_person_timeline_note_create_serializes_fields() -> None:
+    """PersonTimelineNoteCreate should serialize optional fields to primitives."""
+
+    payload = PersonTimelineNoteCreate(
+        person_id="person-123",
+        content="## Memory\n- Detail",
+        date_on=date(2025, 9, 20),
+    )
+
+    serialized = json.loads(payload.model_dump_json(exclude_none=True))
+
+    assert serialized == {
+        "person_id": "person-123",
+        "content": "## Memory\n- Detail",
+        "date_on": "2025-09-20",
+    }
+
+
+def test_person_timeline_note_create_drops_none_fields() -> None:
+    """None values should be omitted when serializing the create payload."""
+
+    payload = PersonTimelineNoteCreate(person_id="person-456", content=None, date_on=None)
+
+    serialized = json.loads(payload.model_dump_json(exclude_none=True))
+
+    assert serialized == {"person_id": "person-456"}
+
+
+def test_person_timeline_note_create_rejects_unknown_fields() -> None:
+    """Unexpected fields should raise a validation error."""
+
+    with pytest.raises(ValidationError):
+        PersonTimelineNoteCreate(person_id="person-789", content="Note", unexpected="value")
+
+
+def test_person_timeline_note_response_parses_dates_and_timestamps() -> None:
+    """Wrapped response data should parse ISO dates and timestamps."""
+
+    response = PersonTimelineNoteResponse(
+        id="note-123",
+        date_on="2025-09-21",
+        created_at="2025-09-21T15:39:25Z",
+        updated_at="2025-09-22T10:15:00Z",
+    )
+
+    assert response.id == "note-123"
+    assert response.date_on == date(2025, 9, 21)
+    assert response.created_at == datetime(2025, 9, 21, 15, 39, 25, tzinfo=UTC)
+    assert response.updated_at == datetime(2025, 9, 22, 10, 15, tzinfo=UTC)
+
+
+def test_person_timeline_note_response_ignores_unknown_fields() -> None:
+    """Extra response keys from LunaTask should be ignored for forward compatibility."""
+
+    response = PersonTimelineNoteResponse(
+        id="note-456",
+        date_on="2025-09-21",
+        created_at="2025-09-21T15:39:25Z",
+        updated_at="2025-09-22T10:15:00Z",
+        extra_field="ignored",
+    )
+
+    assert response.id == "note-456"
+    assert not hasattr(response, "extra_field")

--- a/tests/test_people_tools_create_person_timeline_note_tool.py
+++ b/tests/test_people_tools_create_person_timeline_note_tool.py
@@ -1,0 +1,274 @@
+"""Unit tests for PeopleTools.create_person_timeline_note_tool()."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import FastMCP
+from pydantic import HttpUrl
+from pytest_mock import MockerFixture
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import (
+    LunaTaskAPIError,
+    LunaTaskAuthenticationError,
+    LunaTaskNetworkError,
+    LunaTaskRateLimitError,
+    LunaTaskServerError,
+    LunaTaskServiceUnavailableError,
+    LunaTaskSubscriptionRequiredError,
+    LunaTaskTimeoutError,
+    LunaTaskValidationError,
+)
+from lunatask_mcp.api.models_people import (
+    PersonTimelineNoteCreate,
+    PersonTimelineNoteResponse,
+)
+from lunatask_mcp.config import ServerConfig
+from lunatask_mcp.tools.people import PeopleTools
+
+
+class TestCreatePersonTimelineNoteTool:
+    """Test suite for create_person_timeline_note MCP tool behavior."""
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_tool_success(self, mocker: MockerFixture) -> None:
+        """Tool should delegate to client and return note identifier on success."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        note_response = PersonTimelineNoteResponse(
+            id="timeline-note-123",
+            date_on="2025-09-22",
+            created_at="2025-09-22T10:15:00Z",
+            updated_at="2025-09-22T10:15:00Z",
+        )
+
+        mocker.patch.object(client, "create_person_timeline_note", return_value=note_response)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_timeline_note_tool(
+            mock_ctx,
+            person_id="person-123",
+            content="Called mom to check in",
+            date_on="2025-09-22",
+        )
+
+        assert result == {
+            "success": True,
+            "person_timeline_note_id": "timeline-note-123",
+            "message": "Person timeline note created successfully",
+        }
+
+        client.create_person_timeline_note.assert_called_once()  # type: ignore[attr-defined]
+        call_payload = client.create_person_timeline_note.call_args[0][0]  # type: ignore[attr-defined]
+        assert isinstance(call_payload, PersonTimelineNoteCreate)
+        assert call_payload.person_id == "person-123"
+        assert call_payload.content == "Called mom to check in"
+        assert call_payload.date_on is not None
+
+        mock_ctx.info.assert_any_call("Creating person timeline note")
+        mock_ctx.info.assert_any_call("Person timeline note created: timeline-note-123")
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_tool_requires_person_id(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Empty person_id should return validation error without client call."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+        mocked_create = mocker.patch.object(client, "create_person_timeline_note")
+
+        result = await people_tools.create_person_timeline_note_tool(
+            mock_ctx,
+            person_id="",
+            content="Something",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert "person_id" in result["message"]
+        mock_ctx.error.assert_awaited_once()  # type: ignore[attr-defined]
+        mocked_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_tool_requires_content(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Blank content should return validation error without invoking client."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+        mocked_create = mocker.patch.object(client, "create_person_timeline_note")
+
+        result = await people_tools.create_person_timeline_note_tool(
+            mock_ctx,
+            person_id="person-123",
+            content="   ",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert "content" in result["message"]
+        mock_ctx.error.assert_awaited_once()  # type: ignore[attr-defined]
+        mocked_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_tool_validates_date(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Invalid ISO date strings should return validation errors."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+        mocked_create = mocker.patch.object(client, "create_person_timeline_note")
+
+        result = await people_tools.create_person_timeline_note_tool(
+            mock_ctx,
+            person_id="person-123",
+            content="Note",
+            date_on="2025/09/22",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert "Invalid date_on" in result["message"]
+        mock_ctx.error.assert_awaited_once()  # type: ignore[attr-defined]
+        mocked_create.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("exception", "error_key"),
+        [
+            (LunaTaskValidationError("Invalid body"), "validation_error"),
+            (LunaTaskSubscriptionRequiredError("Upgrade required"), "subscription_required"),
+            (LunaTaskAuthenticationError("Invalid token"), "authentication_error"),
+            (LunaTaskRateLimitError("Rate limit"), "rate_limit_error"),
+            (LunaTaskServerError("Server exploded"), "server_error"),
+            (LunaTaskServiceUnavailableError("Maintenance"), "server_error"),
+            (LunaTaskTimeoutError("Timeout"), "timeout_error"),
+            (LunaTaskNetworkError("Network down"), "network_error"),
+        ],
+    )
+    async def test_create_person_timeline_note_tool_maps_known_exceptions(
+        self, mocker: MockerFixture, exception: Exception, error_key: str
+    ) -> None:
+        """Known exceptions from client should produce structured error payloads."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(client, "create_person_timeline_note", side_effect=exception)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_timeline_note_tool(
+            mock_ctx,
+            person_id="person-abc",
+            content="Note",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == error_key
+        mock_ctx.error.assert_awaited_once()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_tool_handles_api_error(
+        self, mocker: MockerFixture
+    ) -> None:
+        """API errors should bubble as api_error payloads."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client, "create_person_timeline_note", side_effect=LunaTaskAPIError("Boom")
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_timeline_note_tool(
+            mock_ctx,
+            person_id="person-abc",
+            content="Note",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "api_error"
+        assert "Boom" in result["message"]
+        mock_ctx.error.assert_awaited_once()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_create_person_timeline_note_tool_handles_unexpected_error(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Unexpected exceptions should map to unexpected_error payload."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(client, "create_person_timeline_note", side_effect=ValueError("boom"))
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_timeline_note_tool(
+            mock_ctx,
+            person_id="person-abc",
+            content="Note",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "unexpected_error"
+        assert "boom" in result["message"]
+        mock_ctx.error.assert_awaited_once()  # type: ignore[attr-defined]

--- a/tests/test_people_tools_create_person_timeline_note_tool_e2e.py
+++ b/tests/test_people_tools_create_person_timeline_note_tool_e2e.py
@@ -1,0 +1,126 @@
+"""End-to-end tests for the create_person_timeline_note MCP tool."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp import FastMCP
+from pydantic import HttpUrl
+from pytest_mock import MockerFixture
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import LunaTaskValidationError
+from lunatask_mcp.api.models_people import PersonTimelineNoteResponse
+from lunatask_mcp.config import ServerConfig
+from lunatask_mcp.tools.people import PeopleTools
+
+
+class TestCreatePersonTimelineNoteToolEndToEnd:
+    """E2E validation for create_person_timeline_note tool registration and execution."""
+
+    def test_tool_registered_with_mcp(self) -> None:
+        """Tool should be discoverable with descriptive metadata and schema."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+
+        PeopleTools(mcp, client)
+
+        tool_manager = mcp._tool_manager  # type: ignore[attr-defined]  # testing internal API
+        registered_tools = tool_manager._tools.values()  # type: ignore[attr-defined]
+        tool_names = [tool.name for tool in registered_tools]
+
+        assert "create_person_timeline_note" in tool_names
+
+        create_tool = next(
+            tool for tool in registered_tools if tool.name == "create_person_timeline_note"
+        )
+        assert create_tool.description is not None
+        assert "Create a timeline note" in create_tool.description
+
+        try:
+            if hasattr(create_tool, "input_schema"):
+                schema = getattr(create_tool, "input_schema", None)  # type: ignore[attr-defined]
+                if isinstance(schema, dict) and "properties" in schema:
+                    properties = schema["properties"]  # type: ignore[index]
+                    assert "person_id" in properties
+                    assert "content" in properties
+                    assert "date" in properties
+        except (AttributeError, KeyError, TypeError):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_tool_success_flow(self, mocker: MockerFixture) -> None:
+        """Tool should run end-to-end and return structured success payload."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+        note_response = PersonTimelineNoteResponse(
+            id="timeline-note-789",
+            date_on="2025-09-21",
+            created_at="2025-09-21T09:00:00Z",
+            updated_at="2025-09-21T09:00:00Z",
+        )
+
+        mocker.patch.object(client, "create_person_timeline_note", return_value=note_response)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_timeline_note_tool(
+            ctx=mock_ctx,
+            person_id="person-xyz",
+            content="Called dad to confirm travel plans",
+            date_on="2025-09-21",
+        )
+
+        assert result == {
+            "success": True,
+            "person_timeline_note_id": "timeline-note-789",
+            "message": "Person timeline note created successfully",
+        }
+
+        client.create_person_timeline_note.assert_called_once()  # type: ignore[attr-defined]
+        mock_ctx.info.assert_any_call("Creating person timeline note")
+        mock_ctx.info.assert_any_call("Person timeline note created: timeline-note-789")
+
+    @pytest.mark.asyncio
+    async def test_tool_handles_validation_error(self, mocker: MockerFixture) -> None:
+        """Client validation errors should propagate through structured response."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_person_timeline_note",
+            side_effect=LunaTaskValidationError("Invalid body"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_timeline_note_tool(
+            ctx=mock_ctx,
+            person_id="person-xyz",
+            content="Called dad to confirm travel plans",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        mock_ctx.error.assert_awaited_once()  # type: ignore[attr-defined]

--- a/tests/test_people_tools_create_tool.py
+++ b/tests/test_people_tools_create_tool.py
@@ -1,7 +1,6 @@
 """Tests for PeopleTools.create_person_tool()."""
 
 from datetime import date
-from unittest import mock
 
 import pytest
 from fastmcp import FastMCP
@@ -687,7 +686,14 @@ class TestPeopleToolsInitialization:
 
         PeopleTools(mcp, client)
 
-        mock_tool.assert_called_once_with(
-            name="create_person",
-            description=mock.ANY,
-        )
+        # Two tools are registered.
+        assert mock_tool.call_count == 2  # noqa: PLR2004
+
+        names = [call.kwargs["name"] for call in mock_tool.call_args_list]
+        descriptions = [call.kwargs["description"] for call in mock_tool.call_args_list]
+
+        assert "create_person" in names
+        assert "create_person_timeline_note" in names
+
+        timeline_index = names.index("create_person_timeline_note")
+        assert "Create a timeline note" in descriptions[timeline_index]

--- a/tests/test_people_tools_create_tool.py
+++ b/tests/test_people_tools_create_tool.py
@@ -1,0 +1,693 @@
+"""Tests for PeopleTools.create_person_tool()."""
+
+from datetime import date
+from unittest import mock
+
+import pytest
+from fastmcp import FastMCP
+from pydantic import HttpUrl
+from pytest_mock import MockerFixture
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import (
+    LunaTaskAPIError,
+    LunaTaskAuthenticationError,
+    LunaTaskNetworkError,
+    LunaTaskRateLimitError,
+    LunaTaskServerError,
+    LunaTaskServiceUnavailableError,
+    LunaTaskSubscriptionRequiredError,
+    LunaTaskTimeoutError,
+    LunaTaskValidationError,
+)
+from lunatask_mcp.api.models_people import PersonCreate, PersonRelationshipStrength
+from lunatask_mcp.config import ServerConfig
+from lunatask_mcp.tools.people import PeopleTools
+from tests.factories import create_person_response
+
+
+class TestCreatePersonTool:
+    """Test suite for the create_person MCP tool."""
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_success_all_parameters(self, mocker: MockerFixture) -> None:
+        """Tool should return success payload and person_id on creation with all parameters."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        created_person = create_person_response(
+            person_id="person-123",
+            relationship_strength="business-contacts",
+            source="salesforce",
+            source_id="352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7",
+            email="john.doe@example.com",
+            birthday=date(1985, 3, 20),
+            phone="+1-555-123-4567",
+        )
+
+        mocker.patch.object(client, "create_person", return_value=created_person)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+            relationship_strength="business-contacts",
+            source="salesforce",
+            source_id="352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7",
+            email="john.doe@example.com",
+            birthday="1985-03-20",
+            phone="+1-555-123-4567",
+        )
+
+        assert result == {
+            "success": True,
+            "person_id": "person-123",
+            "message": "Person created successfully",
+        }
+
+        client.create_person.assert_called_once()  # type: ignore[attr-defined]
+        call_arg = client.create_person.call_args[0][0]  # type: ignore[attr-defined]
+        assert isinstance(call_arg, PersonCreate)
+        assert call_arg.first_name == "John"
+        assert call_arg.last_name == "Doe"
+        assert call_arg.relationship_strength == PersonRelationshipStrength.BUSINESS_CONTACTS
+        assert call_arg.source == "salesforce"
+        assert call_arg.source_id == "352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7"
+        assert call_arg.email == "john.doe@example.com"
+        assert call_arg.birthday == date(1985, 3, 20)
+        assert call_arg.phone == "+1-555-123-4567"
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_success_minimal_parameters(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Tool should work with only first_name and last_name parameters."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        created_person = create_person_response(
+            person_id="person-minimal-456",
+            relationship_strength="casual-friends",
+        )
+
+        mocker.patch.object(client, "create_person", return_value=created_person)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="Jane",
+            last_name="Smith",
+        )
+
+        assert result == {
+            "success": True,
+            "person_id": "person-minimal-456",
+            "message": "Person created successfully",
+        }
+
+        client.create_person.assert_called_once()  # type: ignore[attr-defined]
+        call_arg = client.create_person.call_args[0][0]  # type: ignore[attr-defined]
+        assert isinstance(call_arg, PersonCreate)
+        assert call_arg.first_name == "Jane"
+        assert call_arg.last_name == "Smith"
+        assert call_arg.relationship_strength == PersonRelationshipStrength.CASUAL_FRIENDS
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_duplicate_detection(self, mocker: MockerFixture) -> None:
+        """Duplicate detection should return success with duplicate flag."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(client, "create_person", return_value=None)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+            source="salesforce",
+            source_id="existing-id-123",
+        )
+
+        assert result == {
+            "success": True,
+            "duplicate": True,
+            "message": "Person already exists for this source/source_id",
+        }
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_relationship_strength_validation(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Tool should validate relationship_strength parameter values."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        # Test valid relationship strength values
+        for valid_strength in [
+            "family",
+            "intimate-friends",
+            "close-friends",
+            "casual-friends",
+            "acquaintances",
+            "business-contacts",
+            "almost-strangers",
+        ]:
+            created_person = create_person_response(
+                person_id=f"person-{valid_strength}",
+                relationship_strength=valid_strength,
+            )
+
+            mocker.patch.object(client, "create_person", return_value=created_person)
+            mocker.patch.object(client, "__aenter__", return_value=client)
+            mocker.patch.object(client, "__aexit__", return_value=None)
+
+            result = await people_tools.create_person_tool(
+                mock_ctx,
+                first_name="Test",
+                last_name="Person",
+                relationship_strength=valid_strength,
+            )
+
+            assert result["success"] is True
+            assert result["person_id"] == f"person-{valid_strength}"
+
+        # Test invalid relationship strength value
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="Test",
+            last_name="Person",
+            relationship_strength="invalid-strength",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert "Invalid relationship_strength" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_birthday_date_parsing(self, mocker: MockerFixture) -> None:
+        """Tool should parse birthday date strings and handle validation errors."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        # Test valid date parsing
+        created_person = create_person_response(
+            person_id="person-birthday",
+            birthday=date(1990, 12, 25),
+        )
+
+        mocker.patch.object(client, "create_person", return_value=created_person)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="Test",
+            last_name="Person",
+            birthday="1990-12-25",
+        )
+
+        assert result["success"] is True
+        call_arg = client.create_person.call_args[0][0]  # type: ignore[attr-defined]
+        assert call_arg.birthday == date(1990, 12, 25)  # type: ignore[attr-defined]
+
+        # Test invalid date format
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="Test",
+            last_name="Person",
+            birthday="invalid-date",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert "Invalid birthday format" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_validation_error_422(self, mocker: MockerFixture) -> None:
+        """Tool should handle validation errors from API correctly."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_person",
+            side_effect=LunaTaskValidationError("Custom fields for email not defined in app"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+            email="john@example.com",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert "Custom fields for email not defined in app" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_subscription_required_error_402(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Tool should handle subscription required errors correctly."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_person",
+            side_effect=LunaTaskSubscriptionRequiredError("Upgrade required for people management"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "subscription_required"
+        assert "Upgrade required for people management" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_authentication_error_401(self, mocker: MockerFixture) -> None:
+        """Tool should handle authentication errors correctly."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_person",
+            side_effect=LunaTaskAuthenticationError("Invalid bearer token"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "authentication_error"
+        assert "Invalid bearer token" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_rate_limit_error_429(self, mocker: MockerFixture) -> None:
+        """Tool should handle rate limit errors correctly."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_person",
+            side_effect=LunaTaskRateLimitError("Rate limit exceeded"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "rate_limit_error"
+        assert "Rate limit exceeded" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_server_error_5xx(self, mocker: MockerFixture) -> None:
+        """Tool should handle server errors correctly."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_person",
+            side_effect=LunaTaskServerError("Internal server error", status_code=500),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "server_error"
+        assert "Internal server error" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_service_unavailable_error_503(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Tool should handle service unavailable errors correctly."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_person",
+            side_effect=LunaTaskServiceUnavailableError("Service temporarily unavailable"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "server_error"
+        assert "Service temporarily unavailable" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_timeout_error(self, mocker: MockerFixture) -> None:
+        """Tool should handle timeout errors correctly."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_person",
+            side_effect=LunaTaskTimeoutError("Request timeout"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "timeout_error"
+        assert "Request timeout" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_network_error(self, mocker: MockerFixture) -> None:
+        """Tool should handle network errors correctly."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_person",
+            side_effect=LunaTaskNetworkError("Network connection failed"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "network_error"
+        assert "Network connection failed" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_api_error(self, mocker: MockerFixture) -> None:
+        """Tool should handle general API errors correctly."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_person",
+            side_effect=LunaTaskAPIError("API error occurred"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "api_error"
+        assert "API error occurred" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_unexpected_error(self, mocker: MockerFixture) -> None:
+        """Tool should handle unexpected exceptions correctly."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_person",
+            side_effect=RuntimeError("Unexpected error"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "unexpected_error"
+        assert "Unexpected error creating person" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_context_logging_success(self, mocker: MockerFixture) -> None:
+        """Tool should log success cases through FastMCP context."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+        created_person = create_person_response(person_id="person-log-test")
+
+        mocker.patch.object(client, "create_person", return_value=created_person)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+        )
+
+        # Verify context logging calls
+        mock_ctx.info.assert_any_call("Creating new person")
+        mock_ctx.info.assert_any_call("Successfully created person person-log-test")
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_context_logging_error(self, mocker: MockerFixture) -> None:
+        """Tool should log error cases through FastMCP context."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        mocker.patch.object(
+            client,
+            "create_person",
+            side_effect=LunaTaskValidationError("Validation failed"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="John",
+            last_name="Doe",
+        )
+
+        # Verify context error logging
+        mock_ctx.error.assert_called_once()
+        error_message = mock_ctx.error.call_args[0][0]
+        assert "Person validation failed" in error_message
+
+
+class TestPeopleToolsInitialization:
+    """Test PeopleTools initialization and MCP integration."""
+
+    def test_people_tools_initialization(self) -> None:
+        """Test that PeopleTools initializes correctly with MCP and client."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+
+        people_tools = PeopleTools(mcp, client)
+
+        assert people_tools.mcp is mcp
+        assert people_tools.lunatask_client is client
+
+    def test_people_tools_registers_mcp_tools(self, mocker: MockerFixture) -> None:
+        """Test that PeopleTools registers create_person tool with MCP."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+
+        mock_tool = mocker.patch.object(mcp, "tool")
+
+        PeopleTools(mcp, client)
+
+        mock_tool.assert_called_once_with(
+            name="create_person",
+            description=mock.ANY,
+        )

--- a/tests/test_people_tools_create_tool_e2e.py
+++ b/tests/test_people_tools_create_tool_e2e.py
@@ -1,0 +1,341 @@
+"""Tests for PeopleTools create person tool end-to-end validation.
+
+This module contains end-to-end validation tests for the PeopleTools create_person tool
+that validate complete MCP tool functionality from client perspective.
+"""
+
+import inspect
+from datetime import date
+
+import pytest
+from fastmcp import FastMCP
+from pydantic import HttpUrl
+from pytest_mock import MockerFixture
+
+from lunatask_mcp.api.client import LunaTaskClient
+from lunatask_mcp.api.exceptions import LunaTaskValidationError
+from lunatask_mcp.config import ServerConfig
+from lunatask_mcp.tools.people import PeopleTools
+from tests.factories import create_person_response
+
+
+class TestCreatePersonToolEndToEnd:
+    """End-to-end validation tests for create_person tool discoverability and execution."""
+
+    def test_create_person_tool_registered_with_mcp(self) -> None:
+        """Test that create_person tool is properly registered and discoverable via MCP."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+
+        # Initialize PeopleTools to register create_person tool
+        PeopleTools(mcp, client)
+
+        # Verify tool is registered in the MCP server
+        tool_manager = mcp._tool_manager  # type: ignore[attr-defined] # Testing internal API
+        registered_tools = tool_manager._tools.values()  # type: ignore[attr-defined] # Testing internal API
+        tool_names = [tool.name for tool in registered_tools]
+
+        assert "create_person" in tool_names
+
+        # Verify tool has proper schema
+        create_person_tool = next(tool for tool in registered_tools if tool.name == "create_person")
+        assert create_person_tool.description is not None
+        assert "Create a person/contact in LunaTask" in create_person_tool.description
+
+        # Verify tool has expected parameters - using try/except for optional schema inspection
+        try:
+            if hasattr(create_person_tool, "input_schema"):
+                schema = getattr(create_person_tool, "input_schema", None)  # type: ignore[attr-defined] # Optional attribute inspection
+                if isinstance(schema, dict) and "properties" in schema:
+                    properties = schema["properties"]  # type: ignore[index] # Dict access for schema validation
+
+                    # Required parameters
+                    assert "first_name" in properties
+                    assert "last_name" in properties
+
+                    # Optional parameters
+                    expected_optional_params = {
+                        "relationship_strength",
+                        "source",
+                        "source_id",
+                        "email",
+                        "birthday",
+                        "phone",
+                    }
+                    for param in expected_optional_params:
+                        assert param in properties, f"Missing expected parameter: {param}"
+        except (AttributeError, KeyError, TypeError):
+            # Schema inspection is optional - tool registration is the main validation
+            pass
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_complete_execution_flow(self, mocker: MockerFixture) -> None:
+        """Test complete tool execution flow from MCP client perspective."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        # Mock context and successful API response
+        mock_ctx = mocker.AsyncMock()
+        created_person = create_person_response(
+            person_id="e2e-person-123",
+            relationship_strength="business-contacts",
+            source="salesforce",
+            source_id="352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7",
+            email="john.doe@company.com",
+            birthday=date(1985, 5, 15),
+            phone="+1-555-987-6543",
+        )
+
+        mocker.patch.object(client, "create_person", return_value=created_person)
+        mock_context_manager = mocker.AsyncMock()
+        mock_context_manager.__aenter__.return_value = client
+        mock_context_manager.__aexit__.return_value = None
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        # Test tool execution with full parameter set
+        result = await people_tools.create_person_tool(
+            ctx=mock_ctx,
+            first_name="John",
+            last_name="Doe",
+            relationship_strength="business-contacts",
+            source="salesforce",
+            source_id="352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7",
+            email="john.doe@company.com",
+            birthday="1985-05-15",
+            phone="+1-555-987-6543",
+        )
+
+        # Verify successful response structure
+        assert result["success"] is True
+        assert result["person_id"] == "e2e-person-123"
+        assert result["message"] == "Person created successfully"
+
+        # Verify client was called correctly
+        client.create_person.assert_called_once()  # type: ignore[attr-defined]
+        call_arg = client.create_person.call_args[0][0]  # type: ignore[attr-defined]
+
+        # Verify all parameters were correctly passed through
+        assert call_arg.first_name == "John"  # type: ignore[attr-defined]
+        assert call_arg.last_name == "Doe"  # type: ignore[attr-defined]
+        assert call_arg.relationship_strength == "business-contacts"  # type: ignore[attr-defined]
+        assert call_arg.source == "salesforce"  # type: ignore[attr-defined]
+        assert call_arg.source_id == "352fd2d7-cdc0-4e91-a0a3-9d6cc9d440e7"  # type: ignore[attr-defined]
+        assert call_arg.email == "john.doe@company.com"  # type: ignore[attr-defined]
+        assert call_arg.birthday == date(1985, 5, 15)  # type: ignore[attr-defined]
+        assert call_arg.phone == "+1-555-987-6543"  # type: ignore[attr-defined]
+
+        # Verify context logging was called
+        mock_ctx.info.assert_any_call("Creating new person")
+        mock_ctx.info.assert_any_call("Successfully created person e2e-person-123")
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_duplicate_workflow(self, mocker: MockerFixture) -> None:
+        """Test complete duplicate detection workflow."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        # Mock duplicate response (client returns None)
+        mocker.patch.object(client, "create_person", return_value=None)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            ctx=mock_ctx,
+            first_name="Jane",
+            last_name="Doe",
+            source="github",
+            source_id="existing-user-456",
+        )
+
+        # Verify duplicate response structure
+        assert result["success"] is True
+        assert result["duplicate"] is True
+        assert result["message"] == "Person already exists for this source/source_id"
+
+        # Verify context logging for duplicate
+        mock_ctx.info.assert_any_call("Creating new person")
+        mock_ctx.info.assert_any_call("Person already exists; duplicate create skipped")
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_error_handling_workflow(self, mocker: MockerFixture) -> None:
+        """Test complete error handling workflow through the stack."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        # Mock validation error from client
+        mocker.patch.object(
+            client,
+            "create_person",
+            side_effect=LunaTaskValidationError("Custom fields for email not defined in app"),
+        )
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        result = await people_tools.create_person_tool(
+            ctx=mock_ctx,
+            first_name="Test",
+            last_name="User",
+            email="test@example.com",
+        )
+
+        # Verify error response structure
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert "Custom fields for email not defined in app" in result["message"]
+
+        # Verify error was logged to context
+        mock_ctx.error.assert_called_once()
+        error_message = mock_ctx.error.call_args[0][0]
+        assert "Person validation failed" in error_message
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_parameter_validation_workflow(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test parameter validation workflow before API call."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        # Mock client to ensure it's not called due to validation failure
+        mock_create_person = mocker.patch.object(client, "create_person")
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        # Test invalid date format
+        result = await people_tools.create_person_tool(
+            ctx=mock_ctx,
+            first_name="Test",
+            last_name="User",
+            birthday="invalid-date-format",
+        )
+
+        # Verify validation error response
+        assert result["success"] is False
+        assert result["error"] == "validation_error"
+        assert "Invalid birthday format" in result["message"]
+
+        # Verify client was not called due to pre-validation failure
+        mock_create_person.assert_not_called()
+
+        # Verify error was logged to context
+        mock_ctx.error.assert_called_once()
+
+    def test_create_person_tool_integration_with_fastmcp_context(self) -> None:
+        """Test that tool properly integrates with FastMCP context system."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+
+        # Initialize PeopleTools
+        people_tools = PeopleTools(mcp, client)
+
+        # Verify the tool method has proper signature for FastMCP
+        create_person_method = people_tools.create_person_tool
+        signature = inspect.signature(create_person_method)
+
+        # Verify first parameter is context
+        parameters = list(signature.parameters.values())
+        min_params = 3  # ctx, first_name, last_name minimum
+        assert len(parameters) >= min_params
+        assert parameters[0].name == "ctx"
+
+        # Verify required parameters
+        param_names = [param.name for param in parameters]
+        assert "first_name" in param_names
+        assert "last_name" in param_names
+
+        # Verify optional parameters
+        expected_optional = {
+            "relationship_strength",
+            "source",
+            "source_id",
+            "email",
+            "birthday",
+            "phone",
+        }
+        actual_optional = {param.name for param in parameters if param.default is not param.empty}
+        assert expected_optional.issubset(actual_optional)
+
+    @pytest.mark.asyncio
+    async def test_create_person_tool_logging_output_verification(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Test logging output verification through complete execution."""
+
+        mcp = FastMCP("test-server")
+        config = ServerConfig(
+            lunatask_bearer_token="test_token",
+            lunatask_base_url=HttpUrl("https://api.lunatask.app/v1/"),
+        )
+        client = LunaTaskClient(config)
+        people_tools = PeopleTools(mcp, client)
+
+        mock_ctx = mocker.AsyncMock()
+
+        # Mock logger to capture stderr logging
+        mock_logger = mocker.patch("lunatask_mcp.tools.people.logger")
+
+        created_person = create_person_response(person_id="log-test-789")
+
+        mocker.patch.object(client, "create_person", return_value=created_person)
+        mocker.patch.object(client, "__aenter__", return_value=client)
+        mocker.patch.object(client, "__aexit__", return_value=None)
+
+        await people_tools.create_person_tool(
+            mock_ctx,
+            first_name="Log",
+            last_name="Test",
+        )
+
+        # Verify stderr logging calls
+        mock_logger.info.assert_called_with("Successfully created person %s", "log-test-789")
+
+        # Verify FastMCP context logging calls
+        mock_ctx.info.assert_any_call("Creating new person")
+        mock_ctx.info.assert_any_call("Successfully created person log-test-789")
+
+        # Verify no error logging occurred
+        mock_logger.warning.assert_not_called()
+        mock_logger.error.assert_not_called()
+        mock_logger.exception.assert_not_called()
+        mock_ctx.error.assert_not_called()


### PR DESCRIPTION
## Summary
- Implements the `create_person_timeline_note` MCP tool to create timeline notes for people/contacts in LunaTask
- Adds comprehensive API client layer with PersonTimelineNotesClientMixin
- Includes complete test coverage across models, client, and tool layers
- Follows TDD methodology with 11-phase implementation plan

## Changes Made
- **Models**: Added `PersonTimelineNoteCreate` and `PersonTimelineNoteResponse` in `api/models_people.py`
- **Client**: Created `PersonTimelineNotesClientMixin` with async `create_person_timeline_note()` method
- **Tool**: Implemented `create_person_timeline_note_tool` in `tools/people.py` with parameter validation and error handling
- **Tests**: Added comprehensive test coverage for all layers (95%+ coverage maintained)
- **Docs**: Updated architecture docs and API reference documentation

## API Usage
```python
# Creates timeline note for person with optional date
create_person_timeline_note(
    person_id="abc-123", 
    content="Called to check in", 
    date="2025-01-15"  # Optional, defaults to today
)
```

## Test Plan
- [x] Unit tests for models with strict validation
- [x] Client tests covering success/error scenarios 
- [x] Tool tests with parameter validation and API error handling
- [x] End-to-end integration tests with mocked HTTP
- [x] All tests pass with 95%+ coverage maintained
- [x] Type checking passes under strict pyright settings
- [x] Code formatting and linting passes

Fixes #29